### PR TITLE
fix: menu height does not change with the window

### DIFF
--- a/src/qml/ArrowListView.qml
+++ b/src/qml/ArrowListView.qml
@@ -21,36 +21,45 @@
 
 import QtQuick 2.11
 import QtQuick.Window 2.11
+import QtQuick.Layouts 1.11
 import org.deepin.dtk.style 1.0 as DS
 import "private"
 
 FocusScope {
+    id: control
     property int maxVisibleItems : DS.Style.arrowListView.maxVisibleItems
     property int itemHeight:  DS.Style.arrowListView.itemHeight
     property alias view: itemsView
 
     implicitWidth: DS.Style.arrowListView.width
-    implicitHeight: childrenRect.height
+    implicitHeight: contentLayout.implicitHeight
 
-    Column {
-        width: parent.width
-
+    ColumnLayout {
+        id: contentLayout
+        anchors.fill: parent
         ArrowListViewButton {
-            anchors.horizontalCenter: parent.horizontalCenter
+            visible: itemsView.interactive
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: width
+            Layout.preferredHeight: height
             view: itemsView
             direction: ArrowListViewButton.UpButton
         }
 
         ListView {
             id: itemsView
-            width: parent.width
-            implicitHeight: Math.min(contentHeight, maxVisibleItems * DS.Style.arrowListView.itemHeight)
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)
             interactive: Window.window ? (contentHeight > Window.window.height || model.count > maxVisibleItems) : false
             ScrollIndicator.vertical: ScrollIndicator { }
         }
 
         ArrowListViewButton {
-            anchors.horizontalCenter: parent.horizontalCenter
+            visible: itemsView.interactive
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: width
+            Layout.preferredHeight: height
             view: itemsView
             direction: ArrowListViewButton.DownButton
         }

--- a/src/qml/FlowStyle.qml
+++ b/src/qml/FlowStyle.qml
@@ -567,7 +567,7 @@ QtObject {
 
         property QtObject item: QtObject {
             property int width: 180
-            property int height: 30
+            property int height: 34
             property size iconSize: Qt.size(14, 14)
             property int count: 0
         }

--- a/src/qml/Menu.qml
+++ b/src/qml/Menu.qml
@@ -20,6 +20,7 @@
  */
 
 import QtQuick 2.11
+import QtQuick.Layouts 1.11
 import QtQuick.Templates 2.4 as T
 import org.deepin.dtk.impl 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
@@ -54,12 +55,15 @@ T.Menu {
     }
 
     contentItem: FocusScope {
-        implicitHeight: childrenRect.height
+        implicitHeight: viewLayout.implicitHeight
 
-        Column {
-            width: parent.width
+        ColumnLayout {
+            id: viewLayout
+            anchors.fill: parent
+
             Loader {
-                width: parent.width
+                Layout.fillWidth: true
+                Layout.preferredHeight: height
                 sourceComponent: control.header
             }
             ArrowListView {
@@ -67,7 +71,8 @@ T.Menu {
                 property int count: contentView.view.count
 
                 view.model: control.model
-                width: parent.width
+                Layout.fillWidth: true
+                Layout.fillHeight: true
                 view.currentIndex: control.currentIndex
                 maxVisibleItems: control.maxVisibleItems
                 itemHeight: DS.Style.menu.item.height
@@ -84,7 +89,8 @@ T.Menu {
                 Component.onCompleted: refreshContentItemWidth()
             }
             Loader {
-                width: parent.width
+                Layout.fillWidth: true
+                Layout.preferredHeight: height
                 sourceComponent: control.footer
             }
         }

--- a/src/qml/private/ArrowListViewButton.qml
+++ b/src/qml/private/ArrowListViewButton.qml
@@ -35,7 +35,7 @@ Loader {
 
     sourceComponent: Button {
         flat: true
-        enabled: !view.atYBeginning
+        enabled: direction === ArrowListViewButton.UpButton ? !view.atYBeginning : !itemsView.atYEnd
         width: DS.Style.arrowListView.stepButtonSize.width
         height: DS.Style.arrowListView.stepButtonSize.height
         icon.name: direction === ArrowListViewButton.UpButton ? DS.Style.arrowListView.upButtonIconName


### PR DESCRIPTION
The implitHeight property should be independent of the height
property, the implitHeight only updates when the internal space
changes, the height property updates when the external space
changes.

Log:
Bug: https://pms.uniontech.com/bug-view-128715.html
Change-Id: Iee87d5e48b0ccdc58aaae53dff4ddd93abc53237