### PR TITLE
fix: remove some build warnings

### DIFF
--- a/src/dquickblitframebuffer.cpp
+++ b/src/dquickblitframebuffer.cpp
@@ -31,15 +31,15 @@
 
 DQUICK_BEGIN_NAMESPACE
 
-class Q_DECL_HIDDEN TextureProvider : public QSGTextureProvider {
+class Q_DECL_HIDDEN BlitFrameTextureProvider : public QSGTextureProvider {
 public:
-    TextureProvider()
+    BlitFrameTextureProvider()
         : QSGTextureProvider()
     {
 
     }
 
-    QSGTexture *texture() const override {
+    inline QSGTexture *texture() const override {
         return m_texture;
     }
     inline void setTexture(QSGTexture *tex) {
@@ -50,7 +50,6 @@ private:
     QSGTexture *m_texture = nullptr;
 };
 
-
 class Q_DECL_HIDDEN DQuickBlitFramebufferPrivate : public DCORE_NAMESPACE::DObjectPrivate
 {
 public:
@@ -60,7 +59,7 @@ public:
 
     }
 
-    mutable TextureProvider *tp = nullptr;
+    mutable BlitFrameTextureProvider *tp = nullptr;
 };
 
 DQuickBlitFramebuffer::DQuickBlitFramebuffer(QQuickItem *parent)
@@ -92,7 +91,7 @@ QSGTextureProvider *DQuickBlitFramebuffer::textureProvider() const
     }
 
     if (!d->tp) {
-        d->tp = new TextureProvider();
+        d->tp = new BlitFrameTextureProvider();
     }
 
     return d->tp;
@@ -111,7 +110,7 @@ static void onRender(DBlitFramebufferNode *node, void *data) {
         return;
     d->tp->setTexture(node->texture());
     // Don't direct emit the signal, must ensure the signal emit on current render loop after.
-    d->tp->metaObject()->invokeMethod(d->tp, &TextureProvider::textureChanged, Qt::QueuedConnection);
+    d->tp->metaObject()->invokeMethod(d->tp, &BlitFrameTextureProvider::textureChanged, Qt::QueuedConnection);
 }
 
 QSGNode *DQuickBlitFramebuffer::updatePaintNode(QSGNode *oldNode, QQuickItem::UpdatePaintNodeData *oldData)

--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -222,8 +222,6 @@ QQuickWindow *DQuickWindowAttached::window() const
  */
 bool DQuickWindowAttached::isEnabled() const
 {
-    D_DC(DQuickWindowAttached);
-
     return DPlatformHandle::isEnabledDXcb(window());
 }
 

--- a/src/private/dquickinwindowblur.cpp
+++ b/src/private/dquickinwindowblur.cpp
@@ -33,9 +33,9 @@
 
 DQUICK_BEGIN_NAMESPACE
 
-class Q_DECL_HIDDEN TextureProvider : public QSGTextureProvider {
+class Q_DECL_HIDDEN InWindowBlurTextureProvider : public QSGTextureProvider {
 public:
-    TextureProvider()
+    InWindowBlurTextureProvider()
         : QSGTextureProvider()
         , m_texture(new QSGPlainTexture())
     {
@@ -45,7 +45,7 @@ public:
     inline QSGPlainTexture *plainTexture() const {
         return m_texture.data();
     }
-    QSGTexture *texture() const override {
+    inline QSGTexture *texture() const override {
         return plainTexture();
     }
 
@@ -102,7 +102,7 @@ QSGTextureProvider *DQuickInWindowBlur::textureProvider() const
     }
 
     if (!m_tp) {
-        m_tp = new TextureProvider();
+        m_tp = new InWindowBlurTextureProvider();
     }
     return m_tp;
 }
@@ -118,7 +118,7 @@ void onRender(DSGBlurNode *node, void *data) {
         return;
     node->writeToTexture(that->m_tp->plainTexture());
     // Don't direct emit the signal, must ensure the signal emit on current render loop after.
-    that->m_tp->metaObject()->invokeMethod(that->m_tp, &TextureProvider::textureChanged, Qt::QueuedConnection);
+    that->m_tp->metaObject()->invokeMethod(that->m_tp, &InWindowBlurTextureProvider::textureChanged, Qt::QueuedConnection);
 }
 
 QSGNode *DQuickInWindowBlur::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *data)
@@ -157,7 +157,7 @@ QSGNode *DQuickInWindowBlur::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeDa
     }
 
     if (!m_tp) {
-        m_tp = new TextureProvider();
+        m_tp = new InWindowBlurTextureProvider();
     }
 
     node->resize(size());

--- a/src/private/dquickinwindowblur_p.h
+++ b/src/private/dquickinwindowblur_p.h
@@ -35,7 +35,7 @@ QT_END_NAMESPACE
 DQUICK_BEGIN_NAMESPACE
 
 class DQuickInWindowBlendBlurPrivate;
-class TextureProvider;
+class InWindowBlurTextureProvider;
 class DSGBlurNode;
 class DQuickInWindowBlur : public QQuickItem
 {
@@ -71,7 +71,7 @@ private Q_SLOTS:
 private:
     qreal m_radius = 20;
     bool m_offscreen = false;
-    mutable TextureProvider *m_tp = nullptr;
+    mutable InWindowBlurTextureProvider *m_tp = nullptr;
     friend void onRender(DSGBlurNode *, void *);
 };
 

--- a/src/private/dquickkeylistener.cpp
+++ b/src/private/dquickkeylistener.cpp
@@ -127,15 +127,23 @@ bool DQuickKeyListener::eventFilter(QObject *watched, QEvent *event)
     QStringList keyTexts;
     static QList<int> modifierKeys = {Qt::Key_Control, Qt::Key_Shift, Qt::Key_Meta, Qt::Key_Alt};
     if (modifierKeys.contains(key)) {  // Only modifier keys.
-        keyTexts << modifiers.split("+", QString::SkipEmptyParts);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        keyTexts << modifiers.split(QLatin1Char('+'), Qt::SkipEmptyParts);
+#else
+        keyTexts << modifiers.split(QLatin1Char('+'), QString::SkipEmptyParts);
+#endif
     } else {
         key = d->doNativeShiftKey(ke, key);
         QString ks =  QKeySequence(key).toString();
         QKeySequence sequence(modifiers + ks);
         QString writing = sequence.toString();
-        keyTexts << writing.split("+", QString::SkipEmptyParts);
-        if (writing.contains("++"))
-            keyTexts << "+";
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        keyTexts << writing.split(QLatin1Char('+'), Qt::SkipEmptyParts);
+#else
+        keyTexts << writing.split(QLatin1Char('+'), QString::SkipEmptyParts);
+#endif
+        if (writing.contains(QLatin1String("++")))
+            keyTexts << QLatin1String("+");
     }
 
     if (keyTexts.count() > d->maxKeyCount)

--- a/src/private/dquickwaterprogressattribute.cpp
+++ b/src/private/dquickwaterprogressattribute.cpp
@@ -288,7 +288,11 @@ void DQuickWaterProgressAttribute::setBackXOffset(qreal backXOffset)
 QQmlListProperty<WaterPopAttribute> DQuickWaterProgressAttribute::pops()
 {
     D_D(DQuickWaterProgressAttribute);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return QQmlListProperty<WaterPopAttribute>(this, &d->m_pops);
+#else
     return QQmlListProperty<WaterPopAttribute>(this, d->m_pops);
+#endif
 }
 
 bool DQuickWaterProgressAttribute::running() const


### PR DESCRIPTION
1. Ambiguous classes with the same name under different files
2. Obsolete interfaces are wrapped with macro definitions

Log:
Issue: linuxdeepin/developer-center/issues#3316
Change-Id: I3a64b5a19adc8c749a88af4af6c98a5eabde25e4