### PR TITLE
fix: Adjust the style of the FloatingPanel control

### DIFF
--- a/src/private/dquickcontrolpalette_p.h
+++ b/src/private/dquickcontrolpalette_p.h
@@ -383,7 +383,6 @@ private:
     struct PaletteState {
         PaletteState(DQuickControlColorSelector *owner)
             : owner(owner)
-            , controlTheme(DGuiApplicationHelper::LightType)
             , controlState(DQMLGlobalObject::NormalState)
             , family(DQuickControlPalette::CommonColor)
             , familyIsUserSet(false)
@@ -396,7 +395,11 @@ private:
             , inactived(false)
             , inactivedValueValid(false)
         {
-
+            if (auto appHelper = DGuiApplicationHelper::instance()) {
+                controlTheme = appHelper->themeType();
+            } else {
+                controlTheme = DGuiApplicationHelper::LightType;
+            }
         }
 
         DQuickControlColorSelector *owner = nullptr;

--- a/src/qml/FloatingPanel.qml
+++ b/src/qml/FloatingPanel.qml
@@ -30,7 +30,8 @@ Control {
 
     property D.Palette backgroundColor: DS.Style.floatingMessage.panel.background
     property D.Palette dropShadowColor: DS.Style.floatingMessage.panel.dropShadow
-    property D.Palette borderColor: DS.Style.control.border
+    property D.Palette outsideBorderColor: DS.Style.floatingMessage.panel.outsideBorder
+    property D.Palette insideBorderColor: DS.Style.floatingMessage.panel.insideBorder
     // corner radius
     property int radius: DS.Style.floatingMessage.panel.radius
     // blur radius
@@ -53,22 +54,36 @@ Control {
         BoxShadow {
             anchors.fill: backgroundRect
             shadowOffsetX: 0
-            shadowOffsetY: 4
+            shadowOffsetY: 6
             shadowColor: control.D.ColorSelector.dropShadowColor
             shadowBlur: 20
             cornerRadius: backgroundRect.radius
             spread: 0
             hollow: true
         }
+
         Rectangle {
             id: backgroundRect
             anchors.fill: parent
             radius: control.radius
             color: control.D.ColorSelector.backgroundColor
-            border {
-                color: control.D.ColorSelector.borderColor
-                width: DS.Style.control.borderWidth
+        }
+
+        Loader {
+            anchors.fill: backgroundRect
+            active: control.D.ColorSelector.controlTheme === D.ApplicationHelper.DarkType
+            sourceComponent: InsideBoxBorder {
+                radius: backgroundRect.radius
+                color: control.D.ColorSelector.insideBorderColor
+                borderWidth: DS.Style.control.borderWidth
             }
+        }
+
+        OutsideBoxBorder {
+            anchors.fill: backgroundRect
+            radius: backgroundRect.radius
+            color: control.D.ColorSelector.outsideBorderColor
+            borderWidth: DS.Style.control.borderWidth
         }
     }
 }

--- a/src/qml/FlowStyle.qml
+++ b/src/qml/FlowStyle.qml
@@ -523,14 +523,29 @@ QtObject {
             property int radius: 14
             property D.Palette background: D.Palette {
                 normal: Qt.rgba(247 / 255.0, 247 / 255.0, 247 / 255.0, 0.6)
-                normalDark: Qt.rgba(247 / 255.0, 247 / 255.0, 247 / 255.0, 0.6)
+                normalDark: Qt.rgba(20 / 255.0, 20 / 255.0, 20 / 255.0, 0.6)
             }
 
             property D.Palette dropShadow: D.Palette {
                 normal: Qt.rgba(0, 0, 0, 0.2)
                 normalDark: Qt.rgba(0, 0, 0, 0.2)
             }
+
+            property D.Palette outsideBorder: D.Palette {
+                normal: Qt.rgba(0, 0, 0, 0.05)
+                normalDark: Qt.rgba(0, 0, 0, 0.5)
+            }
+
+            property D.Palette insideBorder: D.Palette {
+                normalDark: Qt.rgba(1, 1, 1, 0.05)
+            }
         }
+    }
+
+    property QtObject toolTip: QtObject {
+        property int verticalPadding: 4
+        property int horizontalPadding: 5
+        property int height: 24
     }
 
     property QtObject alertToolTip: QtObject {

--- a/src/qml/ToolTip.qml
+++ b/src/qml/ToolTip.qml
@@ -21,8 +21,8 @@
 
 import QtQuick 2.11
 import QtQuick.Templates 2.4 as T
+import org.deepin.dtk.impl 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
-import "PixelMetric.js" as PM
 
 T.ToolTip {
     id: control
@@ -30,27 +30,28 @@ T.ToolTip {
     x: parent ? (parent.width - implicitWidth) / 2 : 0
     y: -implicitHeight - 3
 
-    implicitWidth: Math.max(background ? background.implicitWidth : 0,
-                            contentItem.implicitWidth + leftPadding + rightPadding)
-    implicitHeight: Math.max(background ? background.implicitHeight : 0,
-                             contentItem.implicitHeight + topPadding + bottomPadding)
+    implicitWidth: DS.Style.control.implicitWidth(control)
+    implicitHeight: DS.Style.control.implicitHeight(control)
 
-    margins: PM.ControlMargin
-    padding: PM.ControlPadding
-
+    topPadding: DS.Style.toolTip.verticalPadding
+    bottomPadding: topPadding
+    leftPadding: DS.Style.toolTip.horizontalPadding
+    rightPadding: leftPadding
     closePolicy: T.Popup.CloseOnEscape | T.Popup.CloseOnPressOutsideParent | T.Popup.CloseOnReleaseOutsideParent
 
     contentItem: Text {
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
         text: control.text
         font: control.font
+        wrapMode: Text.WordWrap
+        opacity: enabled ? 1.0 : 0.4
         color: control.palette.toolTipText
     }
 
-    background: Rectangle {
-        color: control.palette.toolTipBase
-        border.color: "gray"
-        radius: PM.ControlRadius
-        antialiasing: true
-        border.width: 1
+    background: FloatingPanel {
+        implicitWidth: 0
+        implicitHeight: DS.Style.toolTip.height
+        radius: DS.Style.control.radius
     }
 }


### PR DESCRIPTION
1. The FloatingPanel control does not conform to the design, increasing
its inner and outer strokes and adapting to the bright and dark themes.
2. Reimplement the implementation of the tooltip control and delete the
old code.
3. Fix the problem that the default system theme in control palette is
not updated.

Log:
Influence: None
Change-Id: I880a2b73af3c5610cce4bbaab26bdd6a13867ad7