### PR TITLE
fix: Crash caused by the WindowButton control

### DIFF
--- a/src/qml/WindowButtonGroup.qml
+++ b/src/qml/WindowButtonGroup.qml
@@ -90,10 +90,10 @@ RowLayout {
 
         readonly property size maxSize: Qt.size(Window.window.maximumWidth, Window.window.maximumHeight)
         readonly property size minSize: Qt.size(Window.window.minimumWidth, Window.window.minimumHeight)
-        visible: (hasWindowFlag && !__forceHind &&
-                    (__dwindow.motifFunctions & D.WindowManagerHelper.FUNC_RESIZE) &&
-                    maxSize != minSize)
-
+        active: (hasWindowFlag && !__forceHind &&
+                 (__dwindow.motifFunctions & D.WindowManagerHelper.FUNC_RESIZE) &&
+                 maxSize != minSize)
+        visible: active
         enabled: ((__dwindow.motifFunctions & D.WindowManagerHelper.FUNC_MAXIMIZE) &&
                     (__dwindow.motifFunctions & D.WindowManagerHelper.FUNC_RESIZE))
 


### PR DESCRIPTION
A trigger for the `active` property in the Loader was not added
to the partial use of WindowButton due to negligence, causing
the ColorSelector to update the control repeatedly, but because
it was not released, the ParentItem could not be obtained, resulting
in an inability to obtain the qml engine related resources and
causes a crash.

Log:
Influence: None
Change-Id: Ieb8a240044be4e73e8b0dac7dc18417518b951b9