### PR TITLE
fix: icon size abnormal under high-dpi screen

### DIFF
--- a/src/private/dquickimageprovider.cpp
+++ b/src/private/dquickimageprovider.cpp
@@ -231,8 +231,15 @@ QImage DQuickDciIconProvider::requestImage(const QString &id, QSize *size, const
 
     // If the target mode icon didn't found, we should find the normal mode icon
     // and decorate to the target mode.
-    // This boundingSize always contains devicePixelRatio.
-    int boundingSize = qRound(qMax(requestedSize.width(), requestedSize.height()) / devicePixelRatio);
+
+    // When the application uses the AA_UseHighDpiPixmaps attribute,
+    // the boundingSize should typically divide by devicePixelRatio,
+    // see Qt::AA_UseHighDpiPixmaps.
+    int boundingSize = qMax(requestedSize.width(), requestedSize.height());
+    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps)) {
+        boundingSize = qRound(boundingSize / devicePixelRatio);
+    }
+
     const auto currentTheme = toDciTheme(theme);
     auto currentMode = mode;
     DDciIconMatchResult result = dciIcon.matchIcon(boundingSize, currentTheme, currentMode, DDciIcon::DontFallbackMode);


### PR DESCRIPTION
The size of DCI Icon needs to be set in AA_ After using
the usehighdpipixmaps attribute, divide by the device
pixel ratio instead of dividing by this coefficient by
default.

Log:
Change-Id: I5e2d28a6d0f5821770dc0729987788d57aa1a00b