### PR TITLE
fix: disabled item text color not changed

### DIFF
--- a/examples/exhibition/Menu.qml
+++ b/examples/exhibition/Menu.qml
@@ -30,7 +30,10 @@ Column {
                 MenuItem { text: qsTr("打开") }
                 MenuItem { text: qsTr("在新窗口打开") }
                 MenuItem { text: qsTr("在新标签中打开") }
-                MenuItem { text: qsTr("以管理员身份打开") }
+                MenuItem {
+                    text: qsTr("以管理员身份打开")
+                    enabled : false
+                }
                 MenuSeparator {}
                 MenuItem { text: qsTr("复制") }
                 MenuSeparator {}

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -403,6 +403,7 @@ void DQuickControlColorSelector::setControl(QQuickItem *newControl)
             connect(m_control, SIGNAL(pressedChanged()), this, SLOT(updateControlState()));
         }
         connect(m_control, &QQuickItem::enabledChanged, this, &DQuickControlColorSelector::updateControlState);
+        connect(m_control, &QQuickItem::visibleChanged, this, &DQuickControlColorSelector::updateControlState);
         connect(m_control, &QQuickItem::windowChanged, this, &DQuickControlColorSelector::updateControlWindow);
         updateControlWindow();
 


### PR DESCRIPTION
change opacity when item disabled

Bug: https://pms.uniontech.com/bug-view-165235.html
Log: disabled item set opacity 0.4
Change-Id: I73ed6ba6003d4932557f79a16a4fb46975d21581