### PR TITLE
fix: Modify Menu's width error

### DIFF
--- a/src/qml/ArrowListView.qml
+++ b/src/qml/ArrowListView.qml
@@ -14,7 +14,7 @@ FocusScope {
     property int itemHeight:  DS.Style.arrowListView.itemHeight
     property alias view: itemsView
 
-    implicitWidth: DS.Style.arrowListView.width
+    implicitWidth: Math.max(DS.Style.arrowListView.width, contentLayout.implicitWidth)
     implicitHeight: contentLayout.implicitHeight
 
     ColumnLayout {
@@ -34,6 +34,15 @@ FocusScope {
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)
+            implicitWidth:{
+                var maxWidth = 0
+                for (var i = 0; i < itemsView.count; ++i) {
+                    var item = itemsView.model.get(i)
+                    if (item && item.implicitWidth > maxWidth)
+                        maxWidth = item.implicitWidth
+                }
+                return maxWidth
+            }
             interactive: Window.window ? (contentHeight > Window.window.height || model.count > maxVisibleItems) : false
             ScrollIndicator.vertical: ScrollIndicator { }
         }

--- a/src/qml/Menu.qml
+++ b/src/qml/Menu.qml
@@ -37,12 +37,9 @@ T.Menu {
         blurControl: control
     }
 
-    contentItem: FocusScope {
-        implicitHeight: viewLayout.implicitHeight
-
-        ColumnLayout {
+    contentItem: Control {
+        contentItem:  ColumnLayout {
             id: viewLayout
-            anchors.fill: parent
 
             Loader {
                 Layout.fillWidth: true
@@ -64,12 +61,14 @@ T.Menu {
                 {
                     for (var i = 0; i < view.count; ++i) {
                         var item = view.model.get(i)
-                        item.width = view.width
+                        if (item) {
+                            item.width = view.width
+                        }
                     }
                 }
 
                 onCountChanged: refreshContentItemWidth()
-                Component.onCompleted: refreshContentItemWidth()
+                onWidthChanged: refreshContentItemWidth()
             }
             Loader {
                 Layout.fillWidth: true


### PR DESCRIPTION
  Add implicitWidth's binding to get max itemWidth as view's
width.
  Add onWidthChanged to recalculate item's width for
checked Changed.
  TODO: Binding loop detected for property "implicitWidth"，
and calculate item's width.

Log: 暂时解决菜单宽度的计算错误
Influence: 使用了菜单，并且菜单项比默认最小宽度还要大的应用
Change-Id: Ic0f67bc38980adb574f1a5347a718b9ef30b6942