### PR TITLE
fix: Menu'popup can only work once

### DIFF
--- a/src/qml/FloatingPanel.qml
+++ b/src/qml/FloatingPanel.qml
@@ -15,6 +15,7 @@ Control {
     property D.Palette dropShadowColor: DS.Style.floatingPanel.dropShadow
     property D.Palette outsideBorderColor: DS.Style.floatingPanel.outsideBorder
     property D.Palette insideBorderColor: DS.Style.floatingPanel.insideBorder
+    property bool enableOffScreen: true
     // corner radius
     property int radius: DS.Style.floatingPanel.radius
     // blur radius
@@ -24,7 +25,7 @@ Control {
         implicitWidth: DS.Style.floatingPanel.width
         implicitHeight: DS.Style.floatingPanel.height
         radius: blurRadius
-        offscreen: true
+        offscreen: enableOffScreen
 
         D.ItemViewport {
             anchors.fill: parent

--- a/src/qml/Menu.qml
+++ b/src/qml/Menu.qml
@@ -85,6 +85,7 @@ T.Menu {
             implicitHeight: DS.Style.menu.item.height
             radius: DS.Style.menu.radius
             backgroundColor: control.backgroundColor
+            enableOffScreen: false
         }
     }
 }


### PR DESCRIPTION
  Removing offScreen function.
  TODO: 'offScreen' cause menu has rectangle background
in topLeft.

Log: 临时解决菜单首次弹出后需要移动鼠标才能显示的问题
Bug: https://pms.uniontech.com/bug-view-173409.html
Influence: 所有菜单应用，这会导致菜单左上角的圆角下存在直角背景
Change-Id: I353de34f50980303764f0967f2c8c14453a4151e