### PR TITLE
fix: Modify appload's plugin path

### DIFF
--- a/examples/qml-app-template/src/main/CMakeLists.txt
+++ b/examples/qml-app-template/src/main/CMakeLists.txt
@@ -25,6 +25,8 @@ target_link_libraries(${APP_NAME}
     ${DtkDeclarative_LIBRARIES}
     )
 
+add_definitions(-DAPP_PLUGIN_PATH=\"${DTK_QML_APP_PLUGIN_PATH}\")
+
 set_target_properties(${APP_NAME} PROPERTIES INSTALL_RPATH ${DTK_QML_APP_PLUGIN_PATH})
 install(TARGETS ${APP_NAME} DESTINATION ${APP_BIN_INSTALL_DIR})
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../${CMAKE_PROJECT_NAME}.desktop" DESTINATION share/applications)

--- a/examples/qml-app-template/src/main/main.cpp
+++ b/examples/qml-app-template/src/main/main.cpp
@@ -9,10 +9,12 @@ DQUICK_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+    DAppLoader appLoader("org.deepin.%{ProjectName}");
 #ifdef PLUGINPATH
-    DAppLoader appLoader(APP_NAME, PLUGINPATH);
-#else
-    DAppLoader appLoader(APP_NAME);
+    appLoader.addPluginPath(PLUGINPATH);
+#endif
+#ifdef APP_PLUGIN_PATH
+    appLoader.addPluginPath(APP_PLUGIN_PATH);
 #endif
     return appLoader.exec(argc, argv);
 }

--- a/examples/qml-app-template/src/maincomponentplugin/CMakeLists.txt
+++ b/examples/qml-app-template/src/maincomponentplugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(MAINCOMPONENT_LIB_NAME dtkqml-${CMAKE_PROJECT_NAME})
+set(MAINCOMPONENT_LIB_NAME ${CMAKE_PROJECT_NAME}-main)
 
 ###! maincomponent 中可以添加应用的第三方依赖、注册
 ###! 应用的c++和qml类型、进行耗时计算和加载等等。

--- a/examples/qml-app-template/src/maincomponentplugin/maincomponentplugin.h
+++ b/examples/qml-app-template/src/maincomponentplugin/maincomponentplugin.h
@@ -11,7 +11,7 @@ class QQmlComponent;
 class MainComponentPlugin : public QObject, public DTK_QUICK_NAMESPACE::DQmlAppMainWindowInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID DQmlAppMainWindowInterface_iid)
+    Q_PLUGIN_METADATA(IID DQmlAppMainWindowInterface_iid FILE "plugin.json")
     Q_INTERFACES(DTK_QUICK_NAMESPACE::DQmlAppMainWindowInterface)
 public:
     MainComponentPlugin(QObject *parent = nullptr);

--- a/examples/qml-app-template/src/maincomponentplugin/plugin.json
+++ b/examples/qml-app-template/src/maincomponentplugin/plugin.json
@@ -1,0 +1,3 @@
+{
+    "appid": "org.deepin.%{ProjectName}"
+}

--- a/examples/qml-app-template/src/preloadplugin/CMakeLists.txt
+++ b/examples/qml-app-template/src/preloadplugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(PRELOAD_LIB_NAME dtkqml-${CMAKE_PROJECT_NAME}-Preload)
+set(PRELOAD_LIB_NAME ${CMAKE_PROJECT_NAME}-preload)
 
 ###! 请确保 preloadplugin 下仅依赖最少的三方内容，
 ###! 且不做额外的复杂操作，将第三方库和自定义类型放在

--- a/examples/qml-app-template/src/preloadplugin/plugin.json
+++ b/examples/qml-app-template/src/preloadplugin/plugin.json
@@ -1,0 +1,3 @@
+{
+    "appid": "org.deepin.%{ProjectName}"
+}

--- a/examples/qml-app-template/src/preloadplugin/preloadplugin.h
+++ b/examples/qml-app-template/src/preloadplugin/preloadplugin.h
@@ -11,7 +11,7 @@ class QQmlComponent;
 class PreloadPlugin : public QObject, public DTK_QUICK_NAMESPACE::DQmlAppPreloadInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID DQmlAppPreloadInterface_iid)
+    Q_PLUGIN_METADATA(IID DQmlAppPreloadInterface_iid FILE "plugin.json")
     Q_INTERFACES(DTK_QUICK_NAMESPACE::DQmlAppPreloadInterface)
 public:
     PreloadPlugin(QObject *parent = nullptr);

--- a/src/dapploader.h
+++ b/src/dapploader.h
@@ -33,6 +33,9 @@ public:
     DAppLoader(const QString &appName, const QString &appPath = QString(), QObject *parent = nullptr);
     ~DAppLoader();
 
+    void addPluginPath(const QString &dir);
+    QStringList pluginPaths() const;
+
     int exec(int &argc, char **argv);
     static DAppLoader *instance() { return self; }
 

--- a/src/private/dapploader_p.h
+++ b/src/private/dapploader_p.h
@@ -44,7 +44,6 @@ public:
     DAppLoaderPrivate(DAppLoader *qq);
     void ensureLoadPreload();
     void ensureLoadMain();
-    static QObject *ensureInstance(const QString &pluginPath);
     void destoryIncubator(QQmlIncubator *incubator);
     QQmlContext *creationContext(QQmlComponent *component, QObject *obj);
     bool createObjects(const char *propertyName);
@@ -60,9 +59,10 @@ public:
     void _q_onMainComponentStatusChanged(QQmlComponent::Status status);
     void _q_onComponentProgressChanged();
 
-    QString appName;
-    QString mainQmlPlugin;
-    QString preloadQmlPlugin;
+    static QStringList buildinPluginPaths();
+
+    QString appid;
+    QStringList pluginPaths;
     QQmlApplicationEngine *engine;
     QList<QQmlIncubator *> incubators;
     DQuickAppLoaderItem *appRootItem;
@@ -79,6 +79,8 @@ public:
     QScopedPointer<DQmlAppMainWindowInterface> mainInstance;
     QScopedPointer<QGuiApplication> app;
 private:
+    template<class T> T *loadInstance() const;
+
     D_DECLARE_PUBLIC(DAppLoader)
 };
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -13,11 +13,11 @@ isEmpty(LIB_INSTALL_DIR) {
     LIB_INSTALL_DIR = $$[QT_INSTALL_LIBS]
 }
 
-isEmpty(DTK_QML_APP_PLUGIN_PATH) {
-    DTK_QML_APP_PLUGIN_PATH = $$LIB_INSTALL_DIR/$$TARGET/qml-app
+isEmpty(DTK_QML_APP_PLUGIN_SUBPATH) {
+    DTK_QML_APP_PLUGIN_SUBPATH = dtkdeclarative/plugins
 }
 
-DEFINES += DTK_QML_APP_PLUGIN_PATH=\\\"'$$DTK_QML_APP_PLUGIN_PATH'\\\"
+DEFINES += DTK_QML_APP_PLUGIN_SUBPATH=\\\"'$$DTK_QML_APP_PLUGIN_SUBPATH'\\\"
 
 include(src.pri)
 
@@ -41,8 +41,11 @@ template.path = /usr/share/qtcreator/templates/wizards/projects
 
 INSTALLS += includes target template
 
-CMAKE_CONTENT += "set(DTK_QML_APP_PLUGIN_PATH $${DTK_QML_APP_PLUGIN_PATH})"
-MODULE_PRI_CONT += "QT.$${TARGET}.qml_apps = $${DTK_QML_APP_PLUGIN_PATH}"
+CMAKE_CONTENT += "include(GNUInstallDirs)"
+CMAKE_CONTENT += "set(DTK_QML_APP_PLUGIN_PATH ${CMAKE_INSTALL_FULL_LIBDIR}/$${DTK_QML_APP_PLUGIN_SUBPATH})"
+MODULE_PRI_CONT += "QT.$${TARGET}.qml_apps = \$\$[QT_INSTALL_LIBS]/$${DTK_QML_APP_PLUGIN_SUBPATH}"
+
+DEFINES += DTK_QML_APP_PLUGIN_PATH=\\\"'$$[QT_INSTALL_LIBS]/$$DTK_QML_APP_PLUGIN_SUBPATH'\\\"
 
 load(dtk_cmake)
 load(dtk_module)


### PR DESCRIPTION
  using 'appid' filed to identify AppLoad's plugin instead of
plugin's name.
  Modify DTK_QML_APP_PLUGIN_PATH's value in dtkdeclarative's
cmake and pri.
  AppLoad find plugin's path is the order:
custom's addPluginPath ->
env: DTK_QML_PLUGIN_PATH ->
env: LD_LIBRARY_PATH/DTK_QML_APP_PLUGIN_SUBPATH ->
dtkdeclarative install path: DTK_QML_APP_PLUGIN_PATH,
  We suggest user should set plugin's path using 'addPluginPath'.

Log: 修改插件的标识信息，安装路径，查找路径
Influence: 使用了AppLoader的qml应用若没适配可能崩溃
Change-Id: I24260967a814caa94000a63ee91bdbe223560c78