### PR TITLE
fix: Window.enabled is invalid

### DIFF
--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -476,17 +476,26 @@ DWindowManagerHelper::MotifDecorations DQuickWindowAttached::motifDecorations() 
  */
 void DQuickWindowAttached::setEnabled(bool e)
 {
+    D_D(DQuickWindowAttached);
+    d->explicitEnable = e;
     if (e == isEnabled())
         return;
 
-    D_D(DQuickWindowAttached);
     if (!e) {
         d->destoryPlatformHandle();
         Q_EMIT enabledChanged();
         return;
     }
 
-    d->ensurePlatformHandle();
+    if (!d->ensurePlatformHandle()) {
+        QObject::connect(DWindowManagerHelper::instance(), &DWindowManagerHelper::hasNoTitlebarChanged, this,
+                         [this] () {
+            D_D(DQuickWindowAttached);
+            if (d->explicitEnable && DWindowManagerHelper::instance()->hasNoTitlebar())
+                d->ensurePlatformHandle();
+
+        }, Qt::UniqueConnection);
+    }
 }
 
 /*!

--- a/src/private/dquickwindow_p.h
+++ b/src/private/dquickwindow_p.h
@@ -42,6 +42,7 @@ public:
 
     QWindow *window = nullptr;
     DPlatformHandle *handle = nullptr;
+    bool explicitEnable = false;
 
     DWindowManagerHelper::WmWindowTypes wmWindowTypes;
     DWindowManagerHelper::MotifFunctions motifFunctions;


### PR DESCRIPTION
  it's exist when application is startup automatically and wm's
flag fetch `_deepin_no_titlebar` info by error in platformplugin.
  wm's flag is updated when recvs QXcbAtom::_NET_SUPPORTED, and
then emit hasNoTitlebarChanged signal.
  related code is in dde-qt5platformplugins:
  XcbNativeEventFilter::nativeEventFilter(QXcbAtom::_NET_SUPPORTED)
 -> DXcbWmSupport::updateNetWMAtoms
 -> DXcbWmSupport::updateHasNoTitlebar

Log: xcb延迟更新hasNoTitlebar，导致dtkdeclarative的Window.enabled错误
Bug: https://pms.uniontech.com/bug-view-168517.html
Influence: qml重构的授权客户端开机自启时，标题显示错误
Change-Id: I8481fae88a9effe29110647e84c43ebc0bec9558