### PR TITLE
fix: palette invalid when Control's enable changed

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -6,6 +6,7 @@
 #include "dquickglobal_p.h"
 
 #include <DGuiApplicationHelper>
+#include <DObjectPrivate>
 
 #include <QPalette>
 #include <QQuickItem>
@@ -135,6 +136,19 @@ DQuickControlPalette::~DQuickControlPalette()
 
 }
 
+DQuickControlPaletteAttached *DQuickControlPalette::qmlAttachedProperties(QObject *object)
+{
+    auto item = qobject_cast<QQuickItem *>(object);
+
+    if (!item)
+        return nullptr;
+
+    if (!_d_isControlItem(item) && item->property("palette").isNull())
+        return nullptr;
+
+    return new DQuickControlPaletteAttached(item);
+}
+
 bool DQuickControlPalette::enabled() const
 {
     return m_enabled;
@@ -146,6 +160,165 @@ void DQuickControlPalette::setEnabled(bool newEnabled)
         return;
     m_enabled = newEnabled;
     Q_EMIT enabledChanged();
+}
+
+class DQuickControlPaletteAttachedPrivate : public DCORE_NAMESPACE::DObjectPrivate
+{
+    D_DECLARE_PUBLIC(DQuickControlPaletteAttached)
+public:
+    DQuickControlPaletteAttachedPrivate(DCORE_NAMESPACE::DObject *qq)
+      : DObjectPrivate(qq)
+    {
+    }
+    ~DQuickControlPaletteAttachedPrivate() override;
+
+    inline QPalette qpa() const
+    {
+        D_QC(DQuickControlPaletteAttached);
+        return qvariant_cast<QPalette>(q->parent()->property("palette"));
+    }
+
+    QColor m_foreground;
+    QColor m_background;
+    QColor m_highlight;
+    QColor m_highlightForeground;
+};
+DQuickControlPaletteAttachedPrivate::~DQuickControlPaletteAttachedPrivate()
+{
+}
+
+DQuickControlPaletteAttached::DQuickControlPaletteAttached(QQuickItem *parent)
+    : QObject (parent)
+    , DObject(*new DQuickControlPaletteAttachedPrivate(this))
+{
+    Q_ASSERT(parent);
+    connect(parent, SIGNAL(paletteChanged()), this, SIGNAL(paletteChanged()));
+}
+
+DQuickControlPaletteAttached::~DQuickControlPaletteAttached()
+{
+
+}
+
+DDciIconPalette DQuickControlPaletteAttached::palette() const
+{
+    return DDciIconPalette(foreground(), background(), highlight(), highlightForeground());
+}
+
+QColor DQuickControlPaletteAttached::foreground() const
+{
+    D_DC(DQuickControlPaletteAttached);
+    if (!d->m_foreground.isValid())
+        return d->qpa().windowText().color();
+
+    return d->m_foreground;
+}
+
+void DQuickControlPaletteAttached::setForeground(const QColor &foreground)
+{
+    D_D(DQuickControlPaletteAttached);
+    if (d->m_foreground == foreground)
+        return;
+
+    d->m_foreground = foreground;
+    Q_EMIT paletteChanged();
+}
+
+void DQuickControlPaletteAttached::resetForeground()
+{
+    D_D(DQuickControlPaletteAttached);
+    if (!d->m_foreground.isValid())
+        return;
+
+    d->m_foreground = QColor();
+    Q_EMIT paletteChanged();
+}
+
+QColor DQuickControlPaletteAttached::background() const
+{
+    D_DC(DQuickControlPaletteAttached);
+    if (!d->m_background.isValid())
+        return d->qpa().window().color();
+
+    return d->m_background;
+}
+
+void DQuickControlPaletteAttached::setBackground(const QColor &background)
+{
+    D_D(DQuickControlPaletteAttached);
+    if (d->m_background == background)
+        return;
+
+    d->m_background = background;
+    Q_EMIT paletteChanged();
+}
+
+void DQuickControlPaletteAttached::resetBackground()
+{
+    D_D(DQuickControlPaletteAttached);
+    if (!d->m_background.isValid())
+        return;
+
+    d->m_background = QColor();
+    Q_EMIT paletteChanged();
+}
+
+QColor DQuickControlPaletteAttached::highlight() const
+{
+    D_DC(DQuickControlPaletteAttached);
+    if (!d->m_highlight.isValid())
+        return d->qpa().highlight().color();
+
+    return d->m_highlight;
+}
+
+void DQuickControlPaletteAttached::setHighlight(const QColor &highlight)
+{
+    D_D(DQuickControlPaletteAttached);
+    if (d->m_highlight == highlight)
+        return;
+
+    d->m_highlight = highlight;
+    Q_EMIT paletteChanged();
+}
+
+void DQuickControlPaletteAttached::resetHighlight()
+{
+    D_D(DQuickControlPaletteAttached);
+    if (!d->m_highlight.isValid())
+        return;
+
+    d->m_highlight = QColor();
+    Q_EMIT paletteChanged();
+}
+
+QColor DQuickControlPaletteAttached::highlightForeground() const
+{
+    D_DC(DQuickControlPaletteAttached);
+    if (!d->m_highlightForeground.isValid())
+        return d->qpa().highlightedText().color();
+
+    return d->m_highlightForeground;
+}
+
+void DQuickControlPaletteAttached::setHighlightForeground(const QColor &highlightForeground)
+{
+    D_D(DQuickControlPaletteAttached);
+    if (d->m_highlightForeground == highlightForeground)
+        return;
+
+    d->m_highlightForeground = highlightForeground;
+    Q_EMIT paletteChanged();
+}
+
+void DQuickControlPaletteAttached::resetHighlightForeground()
+{
+    D_D(DQuickControlPaletteAttached);
+    if (!d->m_highlightForeground.isValid())
+        return;
+
+    d->m_highlightForeground = QColor();
+    Q_EMIT paletteChanged();
 }
 
 class Q_DECL_HIDDEN CustomMetaObject : public QQmlOpenMetaObject

--- a/src/private/dquickcontrolpalette_p.h
+++ b/src/private/dquickcontrolpalette_p.h
@@ -97,6 +97,7 @@ Q_DECLARE_METATYPE(DTK_QUICK_NAMESPACE::DQuickControlColor)
 
 DQUICK_BEGIN_NAMESPACE
 
+class DQuickControlPaletteAttached;
 class DQuickControlPalette : public QObject
 {
     friend class DQuickControlColorSelector;
@@ -134,6 +135,8 @@ public:
 
     explicit DQuickControlPalette(QObject *parent = nullptr);
     ~DQuickControlPalette();
+
+    static DQuickControlPaletteAttached *qmlAttachedProperties(QObject *object);
 
     bool enabled() const;
     void setEnabled(bool newEnabled);
@@ -247,8 +250,47 @@ public:
 private:
     bool m_enabled = true;
 };
+
+class DQuickControlPaletteAttachedPrivate;
+class DQuickControlPaletteAttached : public QObject, DCORE_NAMESPACE::DObject
+{
+    Q_OBJECT
+    D_DECLARE_PRIVATE(DQuickControlPaletteAttached)
+    Q_PROPERTY(QColor foreground READ foreground WRITE setForeground RESET resetForeground NOTIFY paletteChanged)
+    Q_PROPERTY(QColor background READ background WRITE setBackground RESET resetBackground NOTIFY paletteChanged)
+    Q_PROPERTY(QColor highlight READ highlight WRITE setHighlight RESET resetHighlight NOTIFY paletteChanged)
+    Q_PROPERTY(QColor highlightForeground READ highlightForeground WRITE setHighlightForeground RESET resetHighlightForeground NOTIFY paletteChanged)
+    Q_PROPERTY(DTK_GUI_NAMESPACE::DDciIconPalette palette READ palette NOTIFY paletteChanged)
+
+public:
+    explicit DQuickControlPaletteAttached(QQuickItem *parent);
+    ~DQuickControlPaletteAttached() override;
+
+    DDciIconPalette palette() const;
+
+    QColor foreground() const;
+    void setForeground(const QColor &foreground);
+    void resetForeground();
+
+    QColor background() const;
+    void setBackground(const QColor &background);
+    void resetBackground();
+
+    QColor highlight() const;
+    void setHighlight(const QColor &highlight);
+    void resetHighlight();
+
+    QColor highlightForeground() const;
+    void setHighlightForeground(const QColor &highlightForeground);
+    void resetHighlightForeground();
+
+Q_SIGNALS:
+    void paletteChanged();
+};
+
 DQUICK_END_NAMESPACE
 QML_DECLARE_TYPE(DTK_QUICK_NAMESPACE::DQuickControlPalette)
+QML_DECLARE_TYPEINFO(DTK_QUICK_NAMESPACE::DQuickControlPalette, QML_HAS_ATTACHED_PROPERTIES)
 
 DQUICK_BEGIN_NAMESPACE
 class CustomMetaObject;

--- a/src/qml/ActionButton.qml
+++ b/src/qml/ActionButton.qml
@@ -11,7 +11,7 @@ T.Button {
     id: control
     property D.Palette textColor: DS.Style.button.text
 
-    palette.windowText: pressed ? D.ColorSelector.textColor : undefined
+    D.Palette.foreground: pressed ? D.ColorSelector.textColor : undefined
     opacity: D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
@@ -20,7 +20,7 @@ T.Button {
         height: DS.Style.button.iconSize
     }
     contentItem: D.DciIcon {
-        palette: D.DTK.makeIconPalette(control.palette)
+        palette: control.D.Palette.palette
         mode: control.D.ColorSelector.controlState
         theme: control.D.ColorSelector.controlTheme
         name: control.icon.name

--- a/src/qml/Button.qml
+++ b/src/qml/Button.qml
@@ -22,8 +22,8 @@ T.Button {
     opacity: D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
     D.DciIcon.mode: D.ColorSelector.controlState
     D.DciIcon.theme: D.ColorSelector.controlTheme
-    D.DciIcon.palette: D.DTK.makeIconPalette(palette)
-    palette.windowText: D.ColorSelector.textColor
+    D.DciIcon.palette: control.D.Palette.palette
+    D.Palette.foreground: D.ColorSelector.textColor
     icon {
         width: DS.Style.button.iconSize
         height: DS.Style.button.iconSize

--- a/src/qml/ItemDelegate.qml
+++ b/src/qml/ItemDelegate.qml
@@ -35,11 +35,11 @@ T.ItemDelegate {
     spacing: DS.Style.control.spacing
     checkable: true
     autoExclusive: true
-    palette.windowText: checked && !control.cascadeSelected ? D.ColorSelector.checkedTextColor : undefined
 
+    D.Palette.foreground: checked && !control.cascadeSelected ? D.ColorSelector.checkedTextColor : undefined
     D.DciIcon.mode: D.ColorSelector.controlState
     D.DciIcon.theme: D.ColorSelector.controlTheme
-    D.DciIcon.palette: D.DTK.makeIconPalette(palette)
+    D.DciIcon.palette: control.D.Palette.palette
     icon {
         width: DS.Style.itemDelegate.iconSize
         height: DS.Style.itemDelegate.iconSize

--- a/src/qml/MenuItem.qml
+++ b/src/qml/MenuItem.qml
@@ -25,10 +25,10 @@ T.MenuItem {
     property D.Palette textColor: DS.Style.menu.itemText
     property D.Palette subMenuBackgroundColor: DS.Style.menu.subMenuOpenedBackground
 
-    palette.windowText: D.ColorSelector.textColor
+    D.Palette.foreground: D.ColorSelector.textColor
     D.DciIcon.mode: D.ColorSelector.controlState
     D.DciIcon.theme: D.ColorSelector.controlTheme
-    D.DciIcon.palette: D.DTK.makeIconPalette(palette)
+    D.DciIcon.palette: control.D.Palette.palette
     contentItem: D.IconLabel {
         readonly property real arrowPadding: control.subMenu && control.arrow ? control.arrow.width + control.spacing : 0
         readonly property real indicatorPadding: control.useIndicatorPadding && control.indicator ? control.indicator.width + control.spacing : 0

--- a/src/qml/SliderTipItem.qml
+++ b/src/qml/SliderTipItem.qml
@@ -57,7 +57,7 @@ Control {
             bottomPadding: topPadding
             horizontalAlignment: textHorizontalAlignment
             verticalAlignment: Text.AlignVCenter
-            palette.windowText: control.D.ColorSelector.textColor
+            color: control.D.ColorSelector.textColor
             background: Loader {
                 active: highlight
                 sourceComponent: HighlightPanel { }

--- a/src/qml/SpinBoxIndicator.qml
+++ b/src/qml/SpinBoxIndicator.qml
@@ -19,7 +19,7 @@ Control {
     property int direction
     property D.Palette inactiveBackgroundColor: DS.Style.spinBox.indicator.background
 
-    palette.windowText: control.D.ColorSelector.inactiveBackgroundColor
+    D.Palette.foreground: control.D.ColorSelector.inactiveBackgroundColor
     hoverEnabled: true
     implicitWidth: DS.Style.spinBox.indicator.width
     implicitHeight: spinBox.activeFocus ? spinBox.implicitHeight / 2 : DS.Style.spinBox.indicator.height
@@ -30,7 +30,7 @@ Control {
         D.DciIcon {
             id: icon
             sourceSize.width: DS.Style.spinBox.indicator.iconSize
-            palette: D.DTK.makeIconPalette(control.palette)
+            palette: control.D.Palette.palette
             name: direction === SpinBoxIndicator.IndicatorDirection.UpIndicator ? "entry_spinbox_up" : "entry_spinbox_down"
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme

--- a/src/qml/TitleBar.qml
+++ b/src/qml/TitleBar.qml
@@ -45,7 +45,7 @@ Control {
     property alias enableInWindowBlendBlur: background.active
 
     property D.Palette textColor: DS.Style.button.text
-    palette.windowText: D.ColorSelector.textColor
+    D.Palette.foreground: D.ColorSelector.textColor
     MouseArea {
         id: mouseArea
         anchors.fill: parent
@@ -118,7 +118,7 @@ Control {
                 Layout.alignment: Qt.AlignLeft
                 Layout.leftMargin: 2
                 visible: name
-                palette: D.DTK.makeIconPalette(control.palette)
+                palette: control.D.Palette.palette
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme
             }

--- a/src/qml/ToolButton.qml
+++ b/src/qml/ToolButton.qml
@@ -21,8 +21,8 @@ T.ToolButton {
     opacity: D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
     D.DciIcon.mode: D.ColorSelector.controlState
     D.DciIcon.theme: D.ColorSelector.controlTheme
-    D.DciIcon.palette: D.DTK.makeIconPalette(palette)
-    palette.windowText: D.ColorSelector.textColor
+    D.DciIcon.palette: control.D.Palette.palette
+    D.Palette.foreground: D.ColorSelector.textColor
     D.ColorSelector.family: D.Palette.CrystalColor
     display: D.IconLabel.TextUnderIcon
     font: icon.name ? D.DTK.fontManager.t10: undefined

--- a/src/qml/WindowButton.qml
+++ b/src/qml/WindowButton.qml
@@ -14,11 +14,11 @@ Control {
     property D.Palette textColor: DS.Style.button.text
     property D.Palette backgroundColor: DS.Style.windowButton.background
 
-    palette.windowText: D.ColorSelector.textColor
+    D.Palette.foreground: D.ColorSelector.textColor
     hoverEnabled: true
     contentItem: D.DciIcon {
         id: iconLoader
-        palette: D.DTK.makeIconPalette(control.palette)
+        palette: control.D.Palette.palette
         sourceSize {
             width: DS.Style.windowButton.width
             height: DS.Style.windowButton.height

--- a/src/qml/settings/NavigationTitle.qml
+++ b/src/qml/settings/NavigationTitle.qml
@@ -15,9 +15,9 @@ Control {
     property D.Palette backgroundColor: DS.Style.settings.background
     property D.Palette checkedTextColor: DS.Style.checkedButton.text
 
-    palette.windowText: checked ? D.ColorSelector.checkedTextColor : undefined
     contentItem: Label {
         text: Settings.SettingsGroup.name
+        color: checked ? D.ColorSelector.checkedTextColor : undefined
         font: __getFont(Settings.SettingsGroup.level)
         leftPadding: __getMargin(Settings.SettingsGroup.level)
         topPadding: DS.Style.settings.navigation.textVPadding


### PR DESCRIPTION
  `palette.windowText: palette.highlight` causes binding loop,
`palette.windowText: D.colorSelector.textColor` alse cause that if textColor is using palette.highlight as return value.
  We shouldn't use palette.highlight as palette's windowText in
this way, and here We need D.ColorSelector.textColor as DciIcon.palette.foreground.
  We add a `Palette` attached property to translate from QPalette
to DciPalette.

Log: palette循环绑定，导致enable切换时，颜色获取失效
Bug: https://pms.uniontech.com/bug-view-168405.html Influence: 所有使用了高亮色作为字体颜色的按钮，当按钮切换enabled后，颜色
可能无法正常显示

Change-Id: Ib12ca6afd82e6203c9a95502872ef7302ff089e3