### PR TITLE
fix: DialogWindow's palette Can't change flowing system

### DIFF
--- a/src/private/dquickinwindowblur.cpp
+++ b/src/private/dquickinwindowblur.cpp
@@ -15,6 +15,8 @@
 
 #include <QQuickWindow>
 
+#include <DGuiApplicationHelper>
+DGUI_USE_NAMESPACE
 DQUICK_BEGIN_NAMESPACE
 
 class Q_DECL_HIDDEN InWindowBlurTextureProvider : public QSGTextureProvider {
@@ -41,6 +43,10 @@ DQuickInWindowBlur::DQuickInWindowBlur(QQuickItem *parent)
     : QQuickItem(parent)
 {
     setFlag(QQuickItem::ItemHasContents, true);
+    // TODO, `update` should be called when QSGRenderNode changed.
+    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this](){
+        update();
+    });
 }
 
 DQuickInWindowBlur::~DQuickInWindowBlur()


### PR DESCRIPTION
Log: 切换主题对话框模糊出现
Bug: https://pms.uniontech.com/bug-view-169217.html
Influence: 所有对话框切换主题时颜色错误
Change-Id: I0870d8e68c716feffb6b7b0fc247155bb5070da8