### PR TITLE
fix: ArrowListView's ImplicitWidth error

### DIFF
--- a/src/qml/ArrowListView.qml
+++ b/src/qml/ArrowListView.qml
@@ -35,7 +35,10 @@ FocusScope {
             Layout.fillHeight: true
             implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)
             implicitWidth:{
-                var maxWidth = 0
+                var maxWidth = DS.Style.arrowListView.width
+                if (!itemsView.model || !itemsView.model.hasOwnProperty("get"))
+                    return maxWidth
+
                 for (var i = 0; i < itemsView.count; ++i) {
                     var item = itemsView.model.get(i)
                     if (item && item.implicitWidth > maxWidth)


### PR DESCRIPTION
  Add fallback width for arrowListView.

Log: ArrowListView警告信息
Bug: https://pms.uniontech.com/bug-view-173393.html
Influence: 菜单不显示
Change-Id: Ic187a02987edf87b4ce279318683a9c3b596f6ec