### PR TITLE
fix: null pointer cause crash

### DIFF
--- a/src/private/dblurimagenode.cpp
+++ b/src/private/dblurimagenode.cpp
@@ -567,6 +567,9 @@ void DOpenGLBlurEffectNode::initBlurSahder()
 void DOpenGLBlurEffectNode::applyDaulBlur(QOpenGLFramebufferObject *targetFBO, GLuint sourceTexture, QOpenGLShaderProgram *shader
                                   , const QSGRenderNode::RenderState *state, int matrixUniform, int scale)
 {
+    if (Q_UNLIKELY(!m_item || !m_item->window()))
+        return;
+
     auto context = QOpenGLContext::currentContext();
     Q_ASSERT(context);
     GLuint prevFbo = 0;


### PR DESCRIPTION
  Add a check of null pointer, But it shouldn't have happened.

Log: 显示菜单偶发程序崩溃
Bug: https://pms.uniontech.com/zentao/bug-view-173435.html
Influence: none
Change-Id: I0100eb158f9ddf6909a931204dc6f3752614c78d