### PR TITLE
fix: null pointer cause crash

### DIFF
--- a/src/private/dquickinwindowblur.cpp
+++ b/src/private/dquickinwindowblur.cpp
@@ -104,7 +104,7 @@ static void updateBlurNodeTexture(DBlitFramebufferNode *node, void *blurNode) {
 
 void onRender(DSGBlurNode *node, void *data) {
     DQuickInWindowBlur *that = reinterpret_cast<DQuickInWindowBlur*>(data);
-    if (!that->m_tp)
+    if (!that || !that->m_tp)
         return;
     node->writeToTexture(that->m_tp->plainTexture());
     // Don't direct emit the signal, must ensure the signal emit on current render loop after.


### PR DESCRIPTION
  Add a check of null pointer, But it shouldn't have happened.

Log: 显示菜单偶发程序崩溃
Bug: https://pms.uniontech.com/zentao/bug-view-173435.html
Influence: none
Change-Id: I882ea16297fad232c5d65a4566ede32fca9c468a