### PR TITLE
chore: fix lintian warnings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,6 +46,7 @@ Description: Deepin Tool Kit Gui Devel library
 
 Package: libdtkdeclarative-doc
 Architecture: any
+Depends: ${misc:Depends}
 Description: Deepin Tool Kit Gui Devel library (Document)
  Dtkdeclarative is base library of Deepin Qt/QtQuick applications.
 

--- a/examples/exhibition/CMakeLists.txt
+++ b/examples/exhibition/CMakeLists.txt
@@ -3,7 +3,7 @@ set(BIN_NAME dtk-exhibition)
 find_package(Qt5 REQUIRED COMPONENTS Quick QuickControls2)
 find_package(Dtk REQUIRED COMPONENTS Core Gui)
 
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
+set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie -Wl,--as-needed")
 
 add_executable(${BIN_NAME}
     ${CMAKE_CURRENT_LIST_DIR}/main.cpp 


### PR DESCRIPTION
Add as-need linker flags to fix lintian warning. Add ${misc:Depends} for doc package.

Log: fix lintian warnings.