### PR TITLE
chore: hide private link libraries

### DIFF
--- a/misc/DtkDeclarativeConfig.cmake.in
+++ b/misc/DtkDeclarativeConfig.cmake.in
@@ -1,7 +1,9 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
-find_dependency(Dtk COMPONENTS Core Gui)
-find_dependency(Qt5 COMPONENTS Core Quick DBus)
+find_dependency(DtkCore)
+find_dependency(DtkGui)
+find_dependency(Qt5Core)
+find_dependency(Qt5Quick)
 include(${CMAKE_CURRENT_LIST_DIR}/DtkDeclarativeTargets.cmake)
 set(DTK_QML_APP_PLUGIN_PATH @DTK_QML_APP_PLUGIN_PATH@)
 get_target_property(DtkDeclarative_INCLUDE_DIRS Dtk::Declarative INTERFACE_INCLUDE_DIRECTORIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,13 +56,15 @@ if(USE_QQuickStylePluginPrivate)
     )
 endif()
 
-target_link_libraries(${LIB_NAME} PUBLIC
+target_link_libraries(${LIB_NAME}
+PUBLIC
     Qt5::Core
     Qt5::Quick
-    Qt5::QuickPrivate
-    Qt5::DBus
     Dtk::Core
     Dtk::Gui
+PRIVATE
+    Qt5::QuickPrivate
+    Qt5::DBus
 )
 
 target_include_directories(${LIB_NAME} PUBLIC


### PR DESCRIPTION
Hide Qt5::DBus and Qt5::QuickPrivate that is used privately.

Log: hide private link libraries