### PR TITLE
chore: remove useless macro define

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(${BIN_NAME}
 )
 
 target_compile_definitions(${BIN_NAME} PRIVATE
-    PREFIX="${CMAKE_PREFIX_PATH}"
     BIN_NAME="${BIN_NAME}"
 )
 


### PR DESCRIPTION
PREFIX is not used so we remove it.

Log: remove useless macro define