### PR TITLE
fix: Crash when WindowButton unload

### DIFF
--- a/src/qml/WindowButton.qml
+++ b/src/qml/WindowButton.qml
@@ -9,7 +9,7 @@ import org.deepin.dtk.style 1.0 as DS
 Control {
     id: control
     property alias icon: iconLoader
-    property alias pressed: mouseArea.pressed
+    readonly property bool pressed: mouseArea.pressed
     signal clicked
     property D.Palette textColor: DS.Style.button.text
     property D.Palette backgroundColor: DS.Style.windowButton.background


### PR DESCRIPTION
  This commit doesn't change the effect, But I don't know why it
is ok.
  App is crashed to access WindowButton's alias property of
"pressed" when WindowButton is unload, it means the different between `alias` and `property`.
  We can reoccurrent this bug following these steps:
1. starting dtk-exhibition.
2. clicking bottom page in the left sidebar.
3. switch to anthor page quickly.

  TODO: to locate the problem.

Log: none
Influence: none
Change-Id: I9c9bab1efaea7d94f73e09eda5e6963deef0cbb5