### PR TITLE
chore: Build error in lower doxygen version

### DIFF
--- a/docs/snippets/dtkdeclarative_boxinsetshadow.qml
+++ b/docs/snippets/dtkdeclarative_boxinsetshadow.qml
@@ -1,3 +1,5 @@
+Item {
+
 //! [0]
 Rectangle {
     id: backgroundRect
@@ -93,3 +95,5 @@ BoxInsetShadow {
     cornerRadius: backgroundRect.radius
 }
 //! [4]
+
+}


### PR DESCRIPTION
  Modify snippets's code to be compatible lower doxygen.
  It's ok on 1.9.4 but wrong on 1.8.13.

Log: none
Influence: none
Change-Id: Ibcce8ce29b2f24f26e24268020768ef31292be57