### PR TITLE
fix: ColorSelector Can't support assiging binding express

### DIFF
--- a/examples/qml-inspect/Example_colorselector.qml
+++ b/examples/qml-inspect/Example_colorselector.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -123,6 +123,38 @@ Rectangle {
                         rect2.backgroundColor = otherBackgroundColor
                         rect2Text.textColor = othertextColor
                     }
+                }
+            }
+        }
+    }
+
+    Control {
+        id: initColorSelectorByBinding
+        anchors.left: control1.right
+        anchors.leftMargin: 20
+        width: 500
+        height: 50
+        property Palette textColor: Palette {
+            normal: "blue"
+            hovered: "red"
+        }
+
+        Text {
+            id: bindingColorSelector
+            text: "Whether text color changes flowing control's hovered state.\n(Click to change.)"
+            horizontalAlignment: Qt.AlignHCenter
+            verticalAlignment: Qt.AlignVCenter
+            anchors.fill: parent
+            // Add a Palette property to enable construct ColorSelector
+            property alias textColor: initColorSelectorByBinding.textColor
+            // Assign a binding express for ColorSelector.
+            ColorSelector.hovered: ColorSelector.family === Palette.CommonColor ? false : undefined
+            color: ColorSelector.color.textColor
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bindingColorSelector.ColorSelector.family = bindingColorSelector.ColorSelector.family === Palette.CommonColor ? Palette.CrystalColor : Palette.CommonColor
                 }
             }
         }

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -192,7 +192,7 @@ public:
     }
 
     int metaCall(QObject *o, QMetaObject::Call _c, int _id, void **_a) override {
-        if (_c == QMetaObject::ResetProperty) {
+        if (_c == QMetaObject::ResetProperty && _id >= propertyOffset()) {
             auto ownerObject = owner()->parent();
             const QByteArray &proName = name((_id - propertyOffset()));
             int itemPropertyIndex = ownerObject->metaObject()->indexOfProperty(proName);
@@ -213,7 +213,7 @@ public:
         if (builder.hasNotifySignal()) {
             int slotIndex = owner()->metaObject()->indexOfSlot(COLORPROPERTYCHANGEFUNC);
             if (slotIndex != -1)
-                QMetaObject::connect(owner(), type()->signalOffset() + id, owner(), slotIndex, Qt::UniqueConnection);
+                QMetaObject::connect(object(), type()->signalOffset() + id, owner(), slotIndex, Qt::UniqueConnection);
         }
         return QQmlOpenMetaObject::propertyCreated(id, builder);
     }
@@ -375,6 +375,7 @@ void DQuickControlColorSelector::setupMetaPropertyPalettes(QQuickItem *object)
                        .arg(object->metaObject()->className()).arg(QString::number(reinterpret_cast<quintptr>(object), 16).prepend("0x")).arg(object->objectName()).arg(p.name()));
         updatePaletteFromMetaProperty(p, object);
     }
+    Q_EMIT colorProviderChanged();
 }
 
 QQuickItem *DQuickControlColorSelector::control() const
@@ -612,6 +613,11 @@ QStringList DQuickControlColorSelector::specialObjectNameItems()
 {
     // TODO(Chen Bin): To be determined
     return { QLatin1String("ColorSelectorMaster") };
+}
+
+QObject *DQuickControlColorSelector::colorProvider() const
+{
+    return const_cast<DQuickControlColorSelector *>(this);
 }
 
 bool DQuickControlColorSelector::doGetHoveredRecu(bool *value) const

--- a/src/private/dquickcontrolpalette_p.h
+++ b/src/private/dquickcontrolpalette_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -266,6 +266,7 @@ public:
     Q_PROPERTY(bool pressed READ pressed WRITE setPressed RESET resetPressed NOTIFY pressedChanged)
     Q_PROPERTY(bool disabled READ disabled WRITE setDisabled RESET resetDisabled NOTIFY disabledChanged)
     Q_PROPERTY(bool inactived READ inactived WRITE setInactived RESET resetInactived NOTIFY inactivedChanged)
+    Q_PROPERTY(QObject* color READ colorProvider NOTIFY colorProviderChanged)
     Q_CLASSINFO("DefaultProperty", "palettes")
 
     explicit DQuickControlColorSelector(QQuickItem *parent);
@@ -300,6 +301,8 @@ public:
 
     static QStringList specialObjectNameItems();
 
+    QObject *colorProvider() const;
+
 Q_SIGNALS:
     void controlThemeChanged();
     void controlStateChanged();
@@ -311,6 +314,7 @@ Q_SIGNALS:
     void colorPropertyChanged(const QByteArray &name);
     void colorPropertiesChanged();
     void familyChanged();
+    void colorProviderChanged();
 
 private:
     bool doGetHoveredRecu(bool *value) const;


### PR DESCRIPTION
  Flowing code is ok
  ```
  ColorSelector.hovered: false
  color: ColorSelector.color.textColor
  ```
  But this is error, it can't fetch textColor:
  ```
  ColorSelector.hovered: { return false}
  color: ColorSelector.color.textColor
  ```
  We add a `color` property for ColorSelector to fetch palette's color.
and all palette color's property is changed from `ColorSelector` to `m_colorProvider`.