### PR TITLE
Missing hover in crystalcolor

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -192,7 +192,7 @@ public:
     }
 
     int metaCall(QObject *o, QMetaObject::Call _c, int _id, void **_a) override {
-        if (_c == QMetaObject::ResetProperty) {
+        if (_c == QMetaObject::ResetProperty && _id >= propertyOffset()) {
             auto ownerObject = owner()->parent();
             const QByteArray &proName = name((_id - propertyOffset()));
             int itemPropertyIndex = ownerObject->metaObject()->indexOfProperty(proName);
@@ -213,7 +213,7 @@ public:
         if (builder.hasNotifySignal()) {
             int slotIndex = owner()->metaObject()->indexOfSlot(COLORPROPERTYCHANGEFUNC);
             if (slotIndex != -1)
-                QMetaObject::connect(owner(), type()->signalOffset() + id, owner(), slotIndex, Qt::UniqueConnection);
+                QMetaObject::connect(object(), type()->signalOffset() + id, owner(), slotIndex, Qt::UniqueConnection);
         }
         return QQmlOpenMetaObject::propertyCreated(id, builder);
     }

--- a/src/qml/BoxPanel.qml
+++ b/src/qml/BoxPanel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,8 @@ Item {
     property int boxShadowBlur: 6
     property int boxShadowOffsetY: 4
     property int innerShadowOffsetY1: -1
+    // Background color changes with hover state if `backgroundFlowingHovered` is `true`.
+    property bool backgroundFlowsHovered: true
 
     Loader {
         anchors.fill: backgroundRect
@@ -36,7 +38,7 @@ Item {
         id: backgroundRect
         property alias color1: control.color1
         property alias color2: control.color2
-        D.ColorSelector.hovered: false
+        D.ColorSelector.hovered: backgroundFlowsHovered ? undefined : false
 
         Gradient {
             id: backgroundGradient

--- a/src/qml/ButtonBox.qml
+++ b/src/qml/ButtonBox.qml
@@ -27,5 +27,6 @@ Control {
     background: BoxPanel {
         implicitWidth: DS.Style.buttonBox.width
         implicitHeight: DS.Style.buttonBox.height
+        backgroundFlowsHovered: D.ColorSelector.family === D.Palette.CrystalColor
     }
 }


### PR DESCRIPTION
ColorSelector.hovered was disabled for all family.
  There is a spectial animation as background change flowing hovered
for `CommonColor`.