### PR TITLE
fix: Abnormal display of IconLabel for dci icon

### DIFF
--- a/src/private/dquickiconlabel.cpp
+++ b/src/private/dquickiconlabel.cpp
@@ -49,7 +49,7 @@ void DQuickIconLabelPrivate::createIconImage()
     image->setName(icon.name());
     image->setTheme(icon.theme());
     image->setPalette(icon.palette());
-    image->setSourceSize(QSize(icon.width(), icon.height()));
+    image->setSourceSize(iconSize());
     image->setMode(icon.mode());
     image->setFallbackToQIcon(icon.fallbackToQIcon());
     image->imageItem()->setFallbackSource(icon.source());
@@ -91,7 +91,7 @@ void DQuickIconLabelPrivate::syncImage()
 
     image->setName(icon.name());
     image->setMode(icon.mode());
-    image->setSourceSize(QSize(icon.width(), icon.height()));
+    image->setSourceSize(iconSize());
     image->setPalette(icon.palette());
     image->setTheme(icon.theme());
     image->setFallbackToQIcon(icon.fallbackToQIcon());
@@ -384,6 +384,18 @@ void DQuickIconLabelPrivate::itemDestroyed(QQuickItem *item)
         image = nullptr;
     else if (item == label)
         label = nullptr;
+}
+
+QSize DQuickIconLabelPrivate::iconSize() const
+{
+    D_QC(DQuickIconLabel);
+    // If no size is specified for theme icons, it will use the smallest available size.
+    QSize size(icon.width(), icon.height());
+    if (size.width() <= 0)
+        size.setWidth(q->width());
+    if (size.height() <= 0)
+        size.setHeight(q->height());
+    return size;
 }
 
 DQuickIconLabel::DQuickIconLabel(QQuickItem *parent)

--- a/src/private/dquickiconlabel_p_p.h
+++ b/src/private/dquickiconlabel_p_p.h
@@ -45,6 +45,8 @@ public:
     void itemImplicitHeightChanged(QQuickItem *) override;
     void itemDestroyed(QQuickItem *item) override;
 
+    QSize iconSize() const;
+
     bool mirrored = false;
     DQuickIconLabel::Display display = DQuickIconLabel::TextBesideIcon;
     Qt::Alignment alignment = Qt::AlignCenter;

--- a/src/qml/AboutDialog.qml
+++ b/src/qml/AboutDialog.qml
@@ -43,6 +43,9 @@ DialogWindow {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 0
                 display: D.IconLabel.IconOnly
+                icon.mode: control.D.ColorSelector.controlState
+                icon.theme: control.D.ColorSelector.controlTheme
+                icon.palette: D.DTK.makeIconPalette(control.palette)
             }
             Label {
                 id: productNameLabel

--- a/src/qml/DialogWindow.qml
+++ b/src/qml/DialogWindow.qml
@@ -30,6 +30,7 @@ Window {
     property alias header: titleBar.sourceComponent
     property string icon
     default property alias content: contentLoader.children
+    property alias palette : content.palette
 
     Control {
         id: content


### PR DESCRIPTION
  Fallback to IconLabel's size when unset icon's size.
  Add palette property for Window.

Issue: https://github.com/linuxdeepin/dtkdeclarative/issues/123