### PR TITLE
fix: InWindowBlur doesn't work correctly

### DIFF
--- a/src/private/dblurimagenode.cpp
+++ b/src/private/dblurimagenode.cpp
@@ -575,8 +575,7 @@ void DOpenGLBlurEffectNode::applyDaulBlur(QOpenGLFramebufferObject *targetFBO, G
     GLuint prevFbo = 0;
     context->functions()->glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint *)&prevFbo);
 
-    if (prevFbo != targetFBO->handle())
-        targetFBO->bind();
+    targetFBO->bind();
     QOpenGLFunctions *f = context->functions();
     shader->bind();
 
@@ -616,9 +615,10 @@ void DOpenGLBlurEffectNode::applyDaulBlur(QOpenGLFramebufferObject *targetFBO, G
     f->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     glDisable(GL_TEXTURE_2D);
     shader->release();
+    targetFBO->release();
 
     if (prevFbo != targetFBO->handle())
-        context->functions()->glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
+        f->glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
 }
 
 void DOpenGLBlurEffectNode::applyNoise(GLuint sourceTexture, const QSGRenderNode::RenderState *state)


### PR DESCRIPTION
  It was caused by 442d409ccbb0206dd577aab8351df4580e2bcc04.
  It should to apply targetFBO whenever, and release it when
 rendering completed.

 It doesn't work when we show it firstly:
```
    Item {
        width: 400; height: 400
        InWindowBlur {
            id: blur
            anchors.fill: parent
            radius: 5
            offscreen: true

            ItemViewport {
                anchors.fill: parent
                fixed: true
                sourceItem: parent
                hideSource: false
                radius: 5
            }
            Rectangle {
                anchors.fill: parent
                color: "green"
            }
        }
    }
```
and it's ok if `offscreen` is set false.

Issue: https://github.com/linuxdeepin/dtkdeclarative/issues/121 https://github.com/linuxdeepin/dtk/issues/23