### PR TITLE
fix: RadioButton's text color error

### DIFF
--- a/src/qml/RadioButton.qml
+++ b/src/qml/RadioButton.qml
@@ -59,5 +59,6 @@ T.RadioButton {
         font: control.font
         elide: Text.ElideRight
         verticalAlignment: Text.AlignVCenter
+        color: control.palette.windowText
     }
 }


### PR DESCRIPTION
  Assign palette.windowText to the color property.

Issue: https://github.com/linuxdeepin/dtk/issues/19