### PR TITLE
feat: Migrate qt5 to qt6 for QSGTexture

### DIFF
--- a/src/private/dblitframebuffernode.cpp
+++ b/src/private/dblitframebuffernode.cpp
@@ -105,9 +105,13 @@ public:
                                                || fbo->height() < textureSize.height())))) {
             fbo = shareBuffer ? CachedFBO::getFBO(textureSize, useAtlasTexture)
                               : SharedCachedFBO(new CachedFBO(textureSize));
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // TODO qt6
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             m_texture->setTextureId(fbo->texture());
 #else
+            // binding buffer's texture for proxyTexture.
+            auto wp = QQuickWindowPrivate::get(m_item->window());
+            m_texture->setTextureFromNativeTexture(wp->rhi, static_cast<quint64>(fbo->texture()),
+                                                   0, fbo->size(), {}, {});
 #endif
             m_texture->setHasAlphaChannel(true);
             m_texture->setTextureSize(fbo->size());

--- a/src/private/dmaskeffectnode.cpp
+++ b/src/private/dmaskeffectnode.cpp
@@ -409,10 +409,15 @@ void OpaqueTextureMaterial::setMaskTexture(QSGTexture *texture)
         return;
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // TODO qt6
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (texture->textureId() == m_maskTexture->textureId())
         return;
 #else
+    // TODO support vulkan
+    auto sourceTextureId = (m_maskTexture->nativeInterface<QNativeInterface::QSGOpenGLTexture>())->nativeTexture();
+    auto targetTextureId = (texture->nativeInterface<QNativeInterface::QSGOpenGLTexture>())->nativeTexture();
+    if (sourceTextureId == targetTextureId)
+        return;
 #endif
 
     m_maskTexture = texture;


### PR DESCRIPTION
  TextureId has Dropped in qt6.

Issue: https://github.com/linuxdeepin/dtk/issues/87