### PR TITLE
[WIP] fix: windows width may exceed limit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+dtkdeclarative (5.6.13) unstable; urgency=medium
+
+  * fix: typo
+    Thanks to student-ice
+  * feat: Support switching qt5 and qt6 for cmake(Issue: #87)
+  * fix: Unsupported type for property assignment(Issue: #87)
+  * fix: Crashed while debugging in Qt
+  * feat: Support compiling between Qt5 and Qt6(Issue: #87)
+  * feat: Support QQuickPalette in Qt6(Issue: #87)
+  * feat: Forward ContentMenuEvent in Qt6(Issue: #87)
+  * fix: Qt.color is invalid in qt5(Issue: #87)
+  * fix: windows width may exceed limit(Issue: #69)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Tue, 20 Jun 2023 17:28:06 +0800
+
 dtkdeclarative (5.6.12) unstable; urgency=medium
 
   * fix: a missing library link

--- a/src/qml/DialogWindow.qml
+++ b/src/qml/DialogWindow.qml
@@ -59,11 +59,15 @@ Window {
             }
         }
         Component.onCompleted: {
-            if (control.width <= 0) {
-                control.width = control.implicitWidth
+            if (control.width < control.minimumWidth) {
+                control.width = control.minimumWidth
+            } else if (control.width > control.maximumWidth) {
+                control.width = control.maximumWidth
             }
-            if (control.height <= 0) {
-                control.height = control.implicitHeight
+            if (control.height < control.minimumHeight) {
+                control.height = control.minimumHeight
+            } else if (control.height > control.maximumHeight) {
+                control.height = control.maximumHeight
             }
         }
     }


### PR DESCRIPTION
在对话框中 没有对width进行检查,可能会导致width超出minimumWidth和maximumWidth的限制

implicitWidth参数好像并没有起到作用,因为implicitWidth来源于width的值

https://github.com/myml/dtkdeclarative/blob/79a03a867a40b48833dcc23206ce81246040c722/src/qml/DialogWindow.qml#L28-L29

Log:
Issues: https://github.com/linuxdeepin/dtk/issues/69