### PR TITLE
fix: Report Network error in qt6

### DIFF
--- a/chameleon/CMakeLists.txt
+++ b/chameleon/CMakeLists.txt
@@ -75,7 +75,6 @@ if(EnableDtk6)
         NO_PLUGIN_OPTIONAL
         NO_GENERATE_PLUGIN_SOURCE
         SOURCES ${SRC_FILES}
-        QML_FILES ${QML_FILES}
         RESOURCES ${CMAKE_CURRENT_LIST_DIR}/imports/Chameleon/qml.qrc #   imports/Chameleon/qml.qrc
     )
 endif()


### PR DESCRIPTION
  ${QML_FILES} has been added qml.qrc, now we don't add it to
QML_FILES.
  TODO: Changing plugin's generation.

Issue: https://github.com/linuxdeepin/dtk/issues/87