### PR TITLE
fix: Remove AboutAction's assignment

### DIFF
--- a/qt6/src/qml/AboutAction.qml
+++ b/qt6/src/qml/AboutAction.qml
@@ -5,16 +5,17 @@
 import QtQuick 2.11
 
 Action {
-    id: control; objectName: "_d_about_action"
+    id: control
     text: qsTr("About")
     property Component aboutDialog
-    property QtObject object
+    property QtObject __object
     onTriggered: {
         if (aboutDialog) {
-            if (!object) {
-                object = aboutDialog.createObject(parent)
+            if (!__object) {
+                __object = aboutDialog.createObject(parent)
             }
-            object.show()
+            __object.show()
         }
     }
+    Component.onDestruction: __object.destroy()
 }

--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -158,17 +158,6 @@ Control {
                         AboutAction { aboutDialog: control.aboutDialog }
                         QuitAction { }
                     }
-                    onLoaded: {
-                        for (var i = 0; i < item.count; i++) {
-                            var action = item.actionAt(i)
-                            if (action && action.objectName === "_d_about_action") {
-                                if (!action.aboutDialog) {
-                                    action.aboutDialog = control.aboutDialog
-                                    break
-                                }
-                            }
-                        }
-                    }
                 }
             }
 

--- a/src/qml/AboutAction.qml
+++ b/src/qml/AboutAction.qml
@@ -5,16 +5,17 @@
 import QtQuick 2.11
 
 Action {
-    id: control; objectName: "_d_about_action"
+    id: control
     text: qsTr("About")
     property Component aboutDialog
-    property QtObject object
+    property QtObject __object
     onTriggered: {
         if (aboutDialog) {
-            if (!object) {
-                object = aboutDialog.createObject(parent)
+            if (!__object) {
+                __object = aboutDialog.createObject(parent)
             }
-            object.show()
+            __object.show()
         }
     }
+    Component.onDestruction: __object.destroy()
 }

--- a/src/qml/TitleBar.qml
+++ b/src/qml/TitleBar.qml
@@ -157,17 +157,6 @@ Control {
                         AboutAction { aboutDialog: control.aboutDialog }
                         QuitAction { }
                     }
-                    onLoaded: {
-                        for (var i = 0; i < item.count; i++) {
-                            var action = item.actionAt(i)
-                            if (action && action.objectName === "_d_about_action") {
-                                if (!action.aboutDialog) {
-                                    action.aboutDialog = control.aboutDialog
-                                    break
-                                }
-                            }
-                        }
-                    }
                 }
             }
 


### PR DESCRIPTION
  Don't need to assign aboutDialog property manually.