### PR TITLE
fix: Missing Qml registration info in test project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(DtkDeclarative
     LANGUAGES CXX
 )
 set(LIB_NAME dtkdeclarative)
+set(ENABLE_COV OFF CACHE BOOL "Generate coverage info")
 
 if (${PROJECT_VERSION_MAJOR} STREQUAL "5")
     set(QT_DEFAULT_MAJOR_VERSION "5")
@@ -41,6 +42,8 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+
+include(DtkBuildConfig)
 set(BUILD_DOCS ON CACHE BOOL "Generate doxygen-based documentation")
 
 set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Library install path")
@@ -74,6 +77,15 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast")
 endif ()
+
+set(DDECLARATIVE_TRANSLATIONS_DIR "dtk5/DDeclarative/translations" CACHE STRING "DDeclarative translations directory")
+set(DDECLARATIVE_TRANSLATIONS_PATH "share/${DDECLARATIVE_TRANSLATIONS_DIR}")
+set(TRANSLATIONS_INSTALL_PATH "${DDECLARATIVE_TRANSLATIONS_PATH}")
+
+set(URI "org.deepin.dtk")
+string(REPLACE "." "/" URI_PATH ${URI})
+set(PLUGIN_NAME dtkdeclarativeplugin)
+set(PLUGIN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/plugins)
 
 if(EnableQt5)
     add_subdirectory(src)

--- a/chameleon/CMakeLists.txt
+++ b/chameleon/CMakeLists.txt
@@ -50,7 +50,6 @@ set(SRC_FILES
 if(EnableQt5)
     file(GLOB _qml_files ${QML_FILES})
     set(TARGETPATH "QtQuick/Controls.2/Chameleon")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/plugins/Chameleon")
     set(PLUGIN_INSTALL_DIR "${QML_INSTALL_DIR}/${TARGETPATH}")
 
     qtquick_compiler_add_resources(RESOURCES ${CMAKE_CURRENT_LIST_DIR}/qml.qrc)
@@ -58,7 +57,9 @@ if(EnableQt5)
     add_library(${PLUGIN_NAME} SHARED
         ${SRC_FILES}
         ${RESOURCES} #   qml.qrc
-        ${QML_DIR}
+    )
+    set_target_properties(${PLUGIN_NAME} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${PLUGIN_OUTPUT_DIR}/Chameleon"
     )
 
     find_program(COMPILER
@@ -78,14 +79,13 @@ if(EnableQt5)
 
     set(QML_DIR "${CMAKE_CURRENT_BINARY_DIR}/qmldir")
     configure_file("${CMAKE_CURRENT_LIST_DIR}/qmldir.in" "${QML_DIR}" @ONLY)
-    set(OUT_QML_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/qmldir")
     # copy qmldir
     add_custom_command(TARGET ${PLUGIN_NAME}
        POST_BUILD
        COMMAND ${CMAKE_COMMAND} -E
        copy_if_different
        "${QML_DIR}"    #in-file
-       "${OUT_QML_DIR}"                            #out-file
+       "${PLUGIN_OUTPUT_DIR}/Chameleon/qmldir"                            #out-file
     )
 
     install(TARGETS ${PLUGIN_NAME} DESTINATION ${PLUGIN_INSTALL_DIR})
@@ -104,7 +104,7 @@ if(EnableQt6)
         CLASS_NAME QtQuickControls2ChameleonStylePlugin
         PLUGIN_TARGET ${PLUGIN_NAME}
         OUTPUT_DIRECTORY
-            "${PROJECT_BINARY_DIR}/plugins/Chameleon"
+            "${PLUGIN_OUTPUT_DIR}/Chameleon"
         NO_PLUGIN_OPTIONAL
         NO_GENERATE_PLUGIN_SOURCE
         SOURCES ${SRC_FILES}
@@ -112,6 +112,8 @@ if(EnableQt6)
         RESOURCES qml.qrc
     )
 endif()
+
+dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV})
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Qml

--- a/cmake/DtkBuildConfig.cmake
+++ b/cmake/DtkBuildConfig.cmake
@@ -83,3 +83,20 @@ function(GEN_DTK_CONFIG_HEADER)
 
     set(${_CONFIG_OUTPUT_VARIABLE} ${config_file_path} PARENT_SCOPE)
 endfunction()
+
+function(dtk_extend_target TARGET)
+    set(args_option)
+    set(args_single
+        EnableCov
+    )
+    cmake_parse_arguments(PARSE_ARGV 1 arg "${args_option}" "${args_single}" "${args_multi}")
+
+    if (arg_EnableCov)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            target_compile_options(${TARGET} PRIVATE -fprofile-instr-generate -ftest-coverage)
+        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_compile_options(${TARGET} PRIVATE -fprofile-arcs -ftest-coverage)
+        endif()
+        target_link_libraries(${TARGET} PRIVATE gcov)
+    endif()
+endfunction()

--- a/examples/exhibition/CMakeLists.txt
+++ b/examples/exhibition/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::QuickControls2
     Dtk${DTK_VERSION_MAJOR}::Core
     Dtk${DTK_VERSION_MAJOR}::Gui
-    ${LIB_NAME}
 )
 
 install(TARGETS ${BIN_NAME} DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/qml-inspect/CMakeLists.txt
+++ b/examples/qml-inspect/CMakeLists.txt
@@ -14,5 +14,4 @@ target_link_libraries(${BIN_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Quick 
     Qt${QT_VERSION_MAJOR}::QuickControls2
     Dtk${DTK_VERSION_MAJOR}::Gui
-    ${LIB_NAME}
 )

--- a/qmlplugin/CMakeLists.txt
+++ b/qmlplugin/CMakeLists.txt
@@ -1,38 +1,25 @@
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Qml Quick)
-find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
-find_package(Dtk${DTK_VERSION_MAJOR}Gui REQUIRED)
+include(${PROJECT_SOURCE_DIR}/qmlplugin/targets.cmake)
+add_library(${PLUGIN_NAME} SHARED)
 
-set(URI "org/deepin/dtk")
-set(PLUGIN_NAME dtkdeclarativeplugin)
+dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV})
 
-set(PLUGIN_INSTALL_DIR "${QML_INSTALL_DIR}/${URI}")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/plugins/${URI}")
-
-add_library(${PLUGIN_NAME} SHARED
-    ${CMAKE_CURRENT_LIST_DIR}/qmlplugin_plugin.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/qmlplugin_plugin.h
-    ${CMAKE_CURRENT_LIST_DIR}/qmldir
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+    ${PLUGIN_NAME}_interface
+    ${LIB_NAME}
 )
 
-set(QML_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/qmldir")
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${PLUGIN_OUTPUT_DIR}/${URI_PATH}"
+)
+
 # copy qmldir
 add_custom_command(TARGET ${PLUGIN_NAME}
    POST_BUILD
    COMMAND ${CMAKE_COMMAND} -E
    copy_if_different
-   "${CMAKE_CURRENT_SOURCE_DIR}/qmldir"    #in-file
-   "${QML_DIR}"                            #out-file
+   "${PROJECT_SOURCE_DIR}/qmlplugin/qmldir"    #in-file
+   "${PLUGIN_OUTPUT_DIR}/${URI_PATH}/qmldir"    #out-file
 )
 
-install(TARGETS ${PLUGIN_NAME} DESTINATION ${PLUGIN_INSTALL_DIR})
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/qmldir" DESTINATION ${PLUGIN_INSTALL_DIR})
-
-target_link_libraries(${PLUGIN_NAME} PRIVATE
-    Qt${QT_VERSION_MAJOR}::Qml
-    Qt${QT_VERSION_MAJOR}::QmlPrivate
-    Qt${QT_VERSION_MAJOR}::Quick
-    Qt${QT_VERSION_MAJOR}::QuickPrivate
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
-    ${LIB_NAME}
-)
+install(TARGETS ${PLUGIN_NAME} DESTINATION "${QML_INSTALL_DIR}/${URI_PATH}")
+install(FILES "${PROJECT_SOURCE_DIR}/qmlplugin/qmldir" DESTINATION "${QML_INSTALL_DIR}/${URI_PATH}")

--- a/qmlplugin/targets.cmake
+++ b/qmlplugin/targets.cmake
@@ -1,0 +1,18 @@
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Qml Quick)
+find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR}Gui REQUIRED)
+
+add_library(${PLUGIN_NAME}_interface INTERFACE)
+target_sources(${PLUGIN_NAME}_interface PUBLIC
+    ${PROJECT_SOURCE_DIR}/qmlplugin/qmlplugin_plugin.cpp
+    ${PROJECT_SOURCE_DIR}/qmlplugin/qmlplugin_plugin.h
+)
+
+target_link_libraries(${PLUGIN_NAME}_interface INTERFACE
+    Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::QmlPrivate
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::QuickPrivate
+    Dtk${DTK_VERSION_MAJOR}::Core
+    Dtk${DTK_VERSION_MAJOR}::Gui
+)

--- a/qt6/src/CMakeLists.txt
+++ b/qt6/src/CMakeLists.txt
@@ -1,40 +1,13 @@
-set(DTK_QML_APP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/${LIB_NAME}/qml-app" CACHE STRING "dtk qml app plugin path")
-set(DTK_QML_APP_PLUGIN_SUBPATH "dtkdeclarative/plugins" CACHE STRING "dtk qml app plugin subpath")
-set(DDECLARATIVE_TRANSLATIONS_DIR "dtk5/DDeclarative/translations" CACHE STRING "DDeclarative translations directory")
-set(DDECLARATIVE_TRANSLATIONS_PATH "share/${DDECLARATIVE_TRANSLATIONS_DIR}")
-set(TRANSLATIONS_INSTALL_PATH "${DDECLARATIVE_TRANSLATIONS_PATH}")
-
-# Add secure compiler options
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
-# For mips64
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi")
-endif()
-
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Quick DBus QuickControls2 LinguistTools)
+include(${PROJECT_SOURCE_DIR}/src/targets.cmake)
 
 find_package(Qt${QT_DEFAULT_MAJOR_VERSION}ShaderTools)
-find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
-find_package(Dtk${DTK_VERSION_MAJOR}Gui REQUIRED)
-find_package(PkgConfig REQUIRED)
-
-pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
-
-include(${PROJECT_SOURCE_DIR}/src/src.cmake)
-
-file(GLOB ASSETS_RCS ${PROJECT_SOURCE_DIR}/src/dtkdeclarative_assets.qrc)
-file(GLOB TS_FILES "${PROJECT_SOURCE_DIR}/src/translations/*.ts")
-file(GLOB QML_RCS ${CMAKE_CURRENT_LIST_DIR}/dtkdeclarative_qml.qrc)
 
 qt_add_translation(QM_FILES ${TS_FILES})
 
-include(qml.cmake)
-
+include(${PROJECT_SOURCE_DIR}/qt6/src/qml.cmake)
 qt_add_qml_module(${LIB_NAME}
-    PLUGIN_TARGET ${LIB_NAME}plugin
-    URI "org.deepin.dtk"
+    PLUGIN_TARGET ${PLUGIN_NAME}
+    URI ${URI}
     VERSION "1.0"
     SHARED
     NO_GENERATE_PLUGIN_SOURCE
@@ -45,25 +18,31 @@ qt_add_qml_module(${LIB_NAME}
         ${SRCS} ${HEADERS}
         dquickextendregister_p.h
     OUTPUT_DIRECTORY
-        "${PROJECT_BINARY_DIR}/plugins/org/deepin/dtk"
+        "${PLUGIN_OUTPUT_DIR}/${URI_PATH}"
 )
 
+dtk_extend_target(${LIB_NAME} EnableCov ${ENABLE_COV})
+dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV})
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+    EXPORT_NAME Declarative
+)
+
+target_link_libraries(${LIB_NAME}
+PUBLIC
+    $<BUILD_INTERFACE:${LIB_NAME}_properties>
+PRIVATE
+    ${LIB_NAME}_sources
+)
+
+file(GLOB QML_RCS dtkdeclarative_qml.qrc)
 qt_add_resources(RESOURCES
     ${QML_RCS}
     ${ASSETS_RCS}
 )
-target_sources(${LIB_NAME} PRIVATE
-    ${RESOURCES}
-)
-
-target_link_libraries(${LIB_NAME}plugin PRIVATE
-    ${LIB_NAME}
-)
-
-target_sources(${LIB_NAME}plugin PRIVATE
-    ${PROJECT_SOURCE_DIR}/qmlplugin/qmlplugin_plugin.h
-    ${PROJECT_SOURCE_DIR}/qmlplugin/qmlplugin_plugin.cpp
-)
+target_sources(${LIB_NAME} PRIVATE ${RESOURCES})
 
 qt_add_shaders(${LIB_NAME} "_shaders_ng"
     BATCHABLE
@@ -81,66 +60,14 @@ qt_add_shaders(${LIB_NAME} "_shaders_ng"
         "shaders_ng/shadowmaterial.frag"
 )
 
-target_include_directories(${LIB_NAME} PRIVATE
-    ${PROJECT_SOURCE_DIR}/src
-    ${PROJECT_SOURCE_DIR}/src/private
+include(${PROJECT_SOURCE_DIR}/qmlplugin/targets.cmake)
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+    ${PLUGIN_NAME}_interface
+    ${LIB_NAME}
 )
-
-set_target_properties(${LIB_NAME} PROPERTIES
-    VERSION ${CMAKE_PROJECT_VERSION}
-    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
-    EXPORT_NAME Declarative
-)
-
-target_compile_definitions(${LIB_NAME} PRIVATE
-    DTK_QML_APP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}"
-    DTK_QML_APP_PLUGIN_SUBPATH="${DTK_QML_APP_PLUGIN_SUBPATH}"
-    DDECLARATIVE_TRANSLATIONS_DIR="${DDECLARATIVE_TRANSLATIONS_DIR}"
-)
-
-if(USE_QQuickStylePluginPrivate)
-    target_link_libraries(${LIB_NAME} PRIVATE
-        Qt${QT_VERSION_MAJOR}::QuickControls2Private
-    )
-endif()
-
-target_link_libraries(${LIB_NAME}
-PUBLIC
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Quick
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::QuickPrivate
-PRIVATE
-    Qt${QT_VERSION_MAJOR}::DBus
-    PkgConfig::GL
-)
-
-target_include_directories(${LIB_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/private>
-)
-
-target_include_directories(${LIB_NAME} INTERFACE
-    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
-)
-
-target_link_directories(${LIB_NAME} INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${LIB_INSTALL_DIR}>
-)
-
-# gen dtkdeclarative_config.h
-include(DtkBuildConfig)
-set(options MSG) # print MODULE_NAME D_HEADERS DEST_DIR
-gen_dtk_config_header(MODULE_NAME ${LIB_NAME} HEADERS ${D_HEADERS} DEST_DIR ${CMAKE_CURRENT_BINARY_DIR} OUTPUT_VARIABLE CONFIG_PATH)
-list(APPEND PUBLIC_HEADERS ${CONFIG_PATH})
 
 # Install library
 install(TARGETS ${LIB_NAME} EXPORT DtkDeclarativeTargets DESTINATION "${LIB_INSTALL_DIR}")
-# Install headers
-install(FILES ${PUBLIC_HEADERS} ${D_HEADERS} DESTINATION "${INCLUDE_INSTALL_DIR}")
 # Install export targets
 install(EXPORT DtkDeclarativeTargets NAMESPACE Dtk:: FILE DtkDeclarativeTargets.cmake DESTINATION "${CONFIG_INSTALL_DIR}")
 # Install translations

--- a/qt6/src/qml/WindowButtonGroup.qml
+++ b/qt6/src/qml/WindowButtonGroup.qml
@@ -34,6 +34,7 @@ RowLayout {
     }
 
     Loader {
+        objectName: "minimizeBtn"
         property bool hasWindowFlag/*: (Window.window.flags & Qt.WindowMinimizeButtonHint)*/
         Component.onCompleted: hasWindowFlag = (Window.window.flags & Qt.WindowMinimizeButtonHint)
         active: hasWindowFlag &&  !__forceHind
@@ -49,6 +50,7 @@ RowLayout {
     }
 
     Loader {
+        objectName: "quitFullBtn"
         active: !(!control.fullScreenButtonVisible ||
                   !__dwindow.enabled ||
                   Window.window.visibility !== Window.FullScreen)
@@ -68,7 +70,7 @@ RowLayout {
     }
 
     Loader {
-        id: maxOrWindedBtn
+        id: maxOrWindedBtn; objectName: "maxOrWindedBtn"
         property bool hasWindowFlag/*: (Window.window.flags & Qt.WindowMaximizeButtonHint)*/
         Component.onCompleted: hasWindowFlag = (Window.window.flags & Qt.WindowMaximizeButtonHint)
 
@@ -90,6 +92,7 @@ RowLayout {
     }
 
     Loader {
+        objectName: "closeBtn"
         property bool hasWindowFlag/*: (Window.window.flags & Qt.WindowCloseButtonHint)*/
         Component.onCompleted: hasWindowFlag = (Window.window.flags & Qt.WindowCloseButtonHint)
         active: hasWindowFlag && __dwindow.enabled

--- a/qt6/src/qml/private/CMakeLists.txt
+++ b/qt6/src/qml/private/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 qt_add_qml_module(dtkdeclarativeprivatesplugin
     PLUGIN_TARGET dtkdeclarativeprivatesplugin
-    URI "org.deepin.dtk.private"
+    URI "${URI}.private"
     VERSION "1.0"
     QML_FILES
         "ProgressBarImpl.qml"
@@ -15,8 +15,10 @@ qt_add_qml_module(dtkdeclarativeprivatesplugin
         "ButtonPanel.qml"
         "KeySequenceLabel.qml"
     OUTPUT_DIRECTORY
-        "${PROJECT_BINARY_DIR}/plugins/org/deepin/dtk/private"
+        "${PLUGIN_OUTPUT_DIR}/${URI_PATH}/private"
 )
+
+dtk_extend_target(dtkdeclarativeprivatesplugin EnableCov ${ENABLE_COV})
 
 target_link_libraries(dtkdeclarativeprivatesplugin
 PRIVATE

--- a/qt6/src/qml/settings/CMakeLists.txt
+++ b/qt6/src/qml/settings/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 qt_add_qml_module(dtkdeclarativesettingsplugin
     PLUGIN_TARGET dtkdeclarativesettingsplugin
-    URI "org.deepin.dtk.settings"
+    URI "${URI}.settings"
     VERSION "1.0"
     SOURCES
         ${PROJECT_SOURCE_DIR}/src/private/dsettingscontainer_p.h
@@ -19,8 +19,10 @@ qt_add_qml_module(dtkdeclarativesettingsplugin
         "ContentTitle.qml"
         "ContentBackground.qml"
     OUTPUT_DIRECTORY
-        "${PROJECT_BINARY_DIR}/plugins/org/deepin/dtk/settings"
+        "${PLUGIN_OUTPUT_DIR}/${URI_PATH}/settings"
 )
+
+dtk_extend_target(dtkdeclarativesettingsplugin EnableCov ${ENABLE_COV})
 
 target_link_libraries(dtkdeclarativesettingsplugin
 PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,32 +1,9 @@
-set(DTK_QML_APP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/${LIB_NAME}/qml-app" CACHE STRING "dtk qml app plugin path")
-set(DTK_QML_APP_PLUGIN_SUBPATH "dtkdeclarative/plugins" CACHE STRING "dtk qml app plugin subpath")
-set(DDECLARATIVE_TRANSLATIONS_DIR "dtk5/DDeclarative/translations" CACHE STRING "DDeclarative translations directory")
-set(DDECLARATIVE_TRANSLATIONS_PATH "share/${DDECLARATIVE_TRANSLATIONS_DIR}")
-set(TRANSLATIONS_INSTALL_PATH "${DDECLARATIVE_TRANSLATIONS_PATH}")
+include(${PROJECT_SOURCE_DIR}/src/targets.cmake)
 
-# Add secure compiler options
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
-# For mips64
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi")
-endif()
-
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Quick DBus QuickControls2 LinguistTools)
 find_package(Qt${QT_VERSION_MAJOR}QuickCompiler)
-find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
-find_package(Dtk${DTK_VERSION_MAJOR}Gui REQUIRED)
-find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
-
-include(src.cmake)
-
-file(GLOB ASSETS_RCS ${CMAKE_CURRENT_LIST_DIR}/dtkdeclarative_assets.qrc)
-file(GLOB TS_FILES "translations/*.ts")
 # Quick compiler gen qmlc
-file(GLOB QML_RCS ${CMAKE_CURRENT_LIST_DIR}/dtkdeclarative_qml.qrc)
+file(GLOB QML_RCS ${PROJECT_SOURCE_DIR}/src/dtkdeclarative_qml.qrc)
 qtquick_compiler_add_resources(RESOURCES
     ${QML_RCS}
 )
@@ -34,13 +11,11 @@ qtquick_compiler_add_resources(RESOURCES
 qt5_add_translation(QM_FILES ${TS_FILES})
 
 add_library(${LIB_NAME} SHARED
-    ${SRCS}
-    ${HEADERS}
-    ${D_HEADERS}
     ${RESOURCES}
-    ${ASSETS_RCS}
     ${QM_FILES}
 )
+
+dtk_extend_target(${LIB_NAME} EnableCov ${ENABLE_COV})
 
 set_target_properties(${LIB_NAME} PROPERTIES
     VERSION ${CMAKE_PROJECT_VERSION}
@@ -48,55 +23,17 @@ set_target_properties(${LIB_NAME} PROPERTIES
     EXPORT_NAME Declarative
 )
 
-target_compile_definitions(${LIB_NAME} PRIVATE
-    DTK_QML_APP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}"
-    DTK_QML_APP_PLUGIN_SUBPATH="${DTK_QML_APP_PLUGIN_SUBPATH}"
-    DDECLARATIVE_TRANSLATIONS_DIR="${DDECLARATIVE_TRANSLATIONS_DIR}"
-)
-
-if(USE_QQuickStylePluginPrivate)
-    target_link_libraries(${LIB_NAME} PRIVATE
-        Qt${QT_VERSION_MAJOR}::QuickControls2Private
-    )
-endif()
-
 target_link_libraries(${LIB_NAME}
 PUBLIC
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Quick
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
+    $<BUILD_INTERFACE:${LIB_NAME}_properties>
 PRIVATE
-    Qt${QT_VERSION_MAJOR}::QuickPrivate
-    Qt${QT_VERSION_MAJOR}::DBus
-    PkgConfig::GL
+    ${LIB_NAME}_sources
 )
 
-target_include_directories(${LIB_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-)
-
-target_include_directories(${LIB_NAME} INTERFACE
-    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
-)
-
-target_link_directories(${LIB_NAME} INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${LIB_INSTALL_DIR}>
-)
-
-# gen dtkdeclarative_config.h
-include(DtkBuildConfig)
-set(options MSG) # print MODULE_NAME D_HEADERS DEST_DIR
-gen_dtk_config_header(MODULE_NAME ${LIB_NAME} HEADERS ${D_HEADERS} DEST_DIR ${CMAKE_CURRENT_BINARY_DIR} OUTPUT_VARIABLE CONFIG_PATH)
-list(APPEND PUBLIC_HEADERS ${CONFIG_PATH})
+# Install translations
+install(FILES ${QM_FILES} DESTINATION "${TRANSLATIONS_INSTALL_PATH}")
 
 # Install library
 install(TARGETS ${LIB_NAME} EXPORT DtkDeclarativeTargets DESTINATION "${LIB_INSTALL_DIR}")
-# Install headers
-install(FILES ${PUBLIC_HEADERS} ${D_HEADERS} DESTINATION "${INCLUDE_INSTALL_DIR}")
 # Install export targets
 install(EXPORT DtkDeclarativeTargets NAMESPACE Dtk:: FILE DtkDeclarativeTargets.cmake DESTINATION "${CONFIG_INSTALL_DIR}")
-# Install translations
-install(FILES ${QM_FILES} DESTINATION "${TRANSLATIONS_INSTALL_PATH}")

--- a/src/targets.cmake
+++ b/src/targets.cmake
@@ -1,0 +1,76 @@
+# Add secure compiler options
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
+set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
+# For mips64
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi")
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Quick DBus QuickControls2 LinguistTools)
+
+find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
+find_package(Dtk${DTK_VERSION_MAJOR}Gui REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
+
+include(${PROJECT_SOURCE_DIR}/src/src.cmake)
+
+file(GLOB ASSETS_RCS ${PROJECT_SOURCE_DIR}/src/dtkdeclarative_assets.qrc)
+file(GLOB TS_FILES "${PROJECT_SOURCE_DIR}/src/translations/*.ts")
+
+add_library(${LIB_NAME}_properties INTERFACE)
+add_library(${LIB_NAME}_sources INTERFACE)
+target_sources(${LIB_NAME}_sources PUBLIC
+    ${SRCS}
+    ${HEADERS}
+    ${D_HEADERS}
+    ${ASSETS_RCS}
+)
+
+set(DTK_QML_APP_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/${LIB_NAME}/qml-app" CACHE STRING "dtk qml app plugin path")
+set(DTK_QML_APP_PLUGIN_SUBPATH "dtkdeclarative/plugins" CACHE STRING "dtk qml app plugin subpath")
+target_compile_definitions(${LIB_NAME}_properties INTERFACE
+    DTK_QML_APP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}"
+    DTK_QML_APP_PLUGIN_SUBPATH="${DTK_QML_APP_PLUGIN_SUBPATH}"
+    DDECLARATIVE_TRANSLATIONS_DIR="${DDECLARATIVE_TRANSLATIONS_DIR}"
+)
+
+if(USE_QQuickStylePluginPrivate)
+    target_link_libraries(${LIB_NAME}_properties INTERFACE
+        Qt${QT_VERSION_MAJOR}::QuickControls2Private
+    )
+endif()
+
+target_link_libraries(${LIB_NAME}_properties INTERFACE
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Quick
+    Dtk${DTK_VERSION_MAJOR}::Core
+    Dtk${DTK_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::QuickPrivate
+    Qt${QT_VERSION_MAJOR}::DBus
+    PkgConfig::GL
+)
+
+target_include_directories(${LIB_NAME}_properties INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/private>
+)
+
+target_include_directories(${LIB_NAME}_properties INTERFACE
+    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+)
+
+target_link_directories(${LIB_NAME}_properties INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${LIB_INSTALL_DIR}>
+)
+
+# gen dtkdeclarative_config.h
+include(DtkBuildConfig)
+gen_dtk_config_header(MODULE_NAME ${LIB_NAME} HEADERS ${D_HEADERS} DEST_DIR ${CMAKE_CURRENT_BINARY_DIR} OUTPUT_VARIABLE CONFIG_PATH)
+list(APPEND PUBLIC_HEADERS ${CONFIG_PATH})
+# Install headers
+install(FILES ${PUBLIC_HEADERS} ${D_HEADERS} DESTINATION "${INCLUDE_INSTALL_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,62 +19,27 @@ if (EnableDtk5)
     )
 endif()
 
-include(${PROJECT_SOURCE_DIR}/src/src.cmake)
-
-set(CHAMELEON_PATH "${PROJECT_BINARY_DIR}/plugins")
-add_definitions(
-    -DCHAMELEON_PATH="${CHAMELEON_PATH}"
-)
-
 add_executable(${BIN_NAME}
-    main.cpp ${TEST_SOURCES} ${HEADERS} ${SRCS}
+    main.cpp ${TEST_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/data.qrc
-)
-
-target_compile_definitions(${BIN_NAME} PRIVATE
-    BIN_NAME="${BIN_NAME}"
 )
 
 target_compile_options(${BIN_NAME} PRIVATE
     "-fno-access-control"
 )
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(${BIN_NAME} PRIVATE -fprofile-instr-generate -ftest-coverage)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(${BIN_NAME} PRIVATE -fprofile-arcs -ftest-coverage)
-endif()
-
-add_definitions(-DQML_PLUGIN_PATH="${PROJECT_BINARY_DIR}/plugins/")
 
 target_compile_definitions(${BIN_NAME} PRIVATE
-    DTK_QML_APP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}"
-    DTK_QML_APP_PLUGIN_SUBPATH="${DTK_QML_APP_PLUGIN_SUBPATH}"
-    DDECLARATIVE_TRANSLATIONS_DIR="${DDECLARATIVE_TRANSLATIONS_DIR}"
+    QML_PLUGIN_PATH="${PLUGIN_OUTPUT_DIR}"
+    CHAMELEON_PATH="${PLUGIN_OUTPUT_DIR}"
+    BIN_NAME="${BIN_NAME}"
 )
 
-find_package(PkgConfig REQUIRED)
-
-pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
-
 target_link_libraries(${BIN_NAME} PRIVATE
-    Qt${QT_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::CorePrivate
     Qt${QT_VERSION_MAJOR}::Test
-    Qt${QT_VERSION_MAJOR}::Qml
-    Qt${QT_VERSION_MAJOR}::Quick
     Qt${QT_VERSION_MAJOR}::QuickControls2
-    Dtk${DTK_VERSION_MAJOR}::Core
-    Dtk${DTK_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::QuickPrivate
+    ${LIB_NAME}
     GTest::GTest
-    PkgConfig::GL
     pthread
     dl
     m
-    gcov
-)
-
-target_include_directories(${BIN_NAME} PRIVATE
-    ${PROJECT_SOURCE_DIR}/src
 )

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -7,6 +7,19 @@
 #include <QGuiApplication>
 #include <QQuickStyle>
 
+#include <QTimer>
+
+int runTest(QGuiApplication &app)
+{
+    int ret = 0;
+    QTimer::singleShot(0, &app, [&app, &ret]() {
+        ret = RUN_ALL_TESTS();
+        app.quit();
+    });
+    app.exec();
+    return ret;
+}
+
 int main(int argc, char *argv[])
 {
     // 编译时没有显示器，需要指定环境变量
@@ -23,5 +36,5 @@ int main(int argc, char *argv[])
     app.setApplicationName(BIN_NAME);
     ::testing::InitGoogleTest(&argc, argv);
 
-    return RUN_ALL_TESTS();
+    return runTest(app);
 }

--- a/tests/test-recoverage.sh
+++ b/tests/test-recoverage.sh
@@ -24,18 +24,18 @@ export ASAN_OPTIONS="halt_on_error=0"
 
 cd ${SOURCE_DIR}
 
-cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -GNinja
+cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -GNinja -DENABLE_COV=ON
 
 cmake --build ${BUILD_DIR} --target ${TESTS_TARGET}
 
-cd ${TESTS_BUILD_DIR}
+cd ${BUILD_DIR}
 
-./${TESTS_TARGET}
+${TESTS_BUILD_DIR}/${TESTS_TARGET}
 lcov -d ./ -c -o coverage_all.info
 
-lcov --remove coverage_all.info "*/tests/*" "/usr/include*" "*build/src*" ${filter_files[*]} --output-file coverage.info
+lcov --remove coverage_all.info "*/tests/*" "/usr/include*" "*build/*" ${filter_files[*]} --output-file coverage.info
 
 cd ${BUILD_DIR}
-genhtml -o ${HTML_DIR} ${TESTS_BUILD_DIR}/coverage.info && ln -sf ${HTML_DIR}/index.html ${BUILD_DIR}/cov_index.html
+genhtml -o ${HTML_DIR} ${BUILD_DIR}/coverage.info && ln -sf ${HTML_DIR}/index.html ${BUILD_DIR}/cov_index.html
 
 test -e ${TESTS_BUILD_DIR}/asan.log* && mv ${TESTS_BUILD_DIR}/asan.log* ${BUILD_DIR}/asan_index.log

--- a/tests/ut_windowbuttongroup.cpp
+++ b/tests/ut_windowbuttongroup.cpp
@@ -36,16 +36,15 @@ TEST_F(ut_WindowButtonGroup, windowFlags)
 
 TEST_F(ut_WindowButtonGroup, maxOrWinded)
 {
-    TEST_OFFSCREEN_SKIP();
-
     ControlHeler<QQuickWindow> helper("qrc:/qml/WindowButtonGroup.qml");
     ASSERT_TRUE(helper.object);
     helper.object->show();
     QVERIFY(QTest::qWaitForWindowExposed(helper.object));
 
-    qmlRegisterAnonymousType<DQuickWindow>("", 1);
-    auto dwAttached = qobject_cast<DQuickWindowAttached *>(qmlAttachedPropertiesObject<DQuickWindow>(helper.object));
-    ASSERT_TRUE(dwAttached && dwAttached->property("enabled").toBool());
+    auto dwAttached = qobject_cast<DQuickWindowAttached *>(qmlAttachedPropertiesObject<DQuickWindow>(helper.object, false));
+    ASSERT_TRUE(dwAttached);
+    if(!dwAttached->property("enabled").toBool())
+        GTEST_SKIP();
 
     auto content = qvariant_cast<QObject *>(helper.object->property("group"));
     QSignalSpy maxOrWindedSpy(content, SIGNAL(maxOrWinded()));


### PR DESCRIPTION
  Refactor the CMake code for better code reusability between qt5
and qt6.
  the testing project is no longer compiled together with the
source code for code coverage, we add a option `ENABLE_COV`, and recompile the project.
Because the tests also load QML plugins that depend on libraries compiled from the source code, it leads to conflicts between the binary-loaded libraries and the original ones.
As a result, the registration information within QML is lost when loading QML plugins.
  Add EventLoop for unit-test.
  UT is wrong for WindowButtonGroup in qt6.