### PR TITLE
fix: Missing dependency for dtkdeclarative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Homepage: http://www.deepin.org
 
 Package: qml-module-qtquick-controls2-styles-chameleon
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, qml-module-qtquick-shapes (>= 5.11.3),
+Depends: ${shlibs:Depends}, ${misc:Depends}, qml-module-qtquick-shapes (>= 5.11.3), qml-module-qtgraphicaleffects,
  libdtkdeclarative5( =${binary:Version})
 Description: Deepin Tool Kit Qt Quick Controls 2 QML module
  Dtkdeclarative is base library of Deepin Qt/QtQuick applications.


### PR DESCRIPTION
  It reports `module "QtGraphicalEffects" is not installed`