### PR TITLE
feat: Add UT for AppLoader-plugin

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,3 +61,12 @@ target_link_libraries(${BIN_NAME} PRIVATE
     dl
     m
 )
+
+set(APPLOADER_PLUGINDUMP_OUTPUT_DIR ${PROJECT_BINARY_DIR}/plugins)
+target_compile_definitions(${BIN_NAME} PRIVATE
+    APPLOADER_PLUGINDUMP_OUTPUT_DIR="${APPLOADER_PLUGINDUMP_OUTPUT_DIR}"
+)
+set(PRELOAD_LIB_NAME apploader-plugindump-preload)
+set(MAINCOMPONENT_LIB_NAME apploader-plugindump-main)
+add_subdirectory(apploaderplugindump)
+add_dependencies(${BIN_NAME} ${PRELOAD_LIB_NAME} ${MAINCOMPONENT_LIB_NAME})

--- a/tests/apploaderplugindump/CMakeLists.txt
+++ b/tests/apploaderplugindump/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(preloadplugin)
+add_subdirectory(maincomponentplugin)

--- a/tests/apploaderplugindump/maincomponentplugin/CMakeLists.txt
+++ b/tests/apploaderplugindump/maincomponentplugin/CMakeLists.txt
@@ -1,0 +1,20 @@
+if(EnableQt5)
+    qtquick_compiler_add_resources(MAINCOMPONENT_RCC_SOURCES maincomponent.qrc)
+endif()
+if(EnableQt6)
+    qt_add_resources(MAINCOMPONENT_RCC_SOURCES maincomponent.qrc)
+endif()
+
+# Add LIB
+add_library(${MAINCOMPONENT_LIB_NAME} SHARED
+    maincomponentplugin.cpp
+    ${MAINCOMPONENT_RCC_SOURCES}
+)
+
+target_link_libraries(${MAINCOMPONENT_LIB_NAME} PRIVATE
+    ${LIB_NAME}
+)
+
+set_target_properties(${MAINCOMPONENT_LIB_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${APPLOADER_PLUGINDUMP_OUTPUT_DIR}"
+)

--- a/tests/apploaderplugindump/maincomponentplugin/main.qml
+++ b/tests/apploaderplugindump/maincomponentplugin/main.qml
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.11
+import org.deepin.dtk 1.0
+
+AppLoader {
+    Component {
+        Rectangle {
+            anchors.centerIn: parent
+            color: "gray"
+        }
+    }
+}

--- a/tests/apploaderplugindump/maincomponentplugin/maincomponent.qrc
+++ b/tests/apploaderplugindump/maincomponentplugin/maincomponent.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/apploader">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/tests/apploaderplugindump/maincomponentplugin/maincomponentplugin.cpp
+++ b/tests/apploaderplugindump/maincomponentplugin/maincomponentplugin.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "maincomponentplugin.h"
+
+#include <QUrl>
+
+DQUICK_USE_NAMESPACE
+
+MainComponentPlugin::MainComponentPlugin(QObject *parent)
+    : QObject(parent)
+{
+
+}
+
+MainComponentPlugin::~MainComponentPlugin()
+{
+
+}
+
+QUrl MainComponentPlugin::mainComponentPath() const
+{
+    return QUrl("qrc:///apploader/main.qml");
+}

--- a/tests/apploaderplugindump/maincomponentplugin/maincomponentplugin.h
+++ b/tests/apploaderplugindump/maincomponentplugin/maincomponentplugin.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef MAINCOMPONENTPLUGIN_H
+#define MAINCOMPONENTPLUGIN_H
+
+#include <dqmlappmainwindowinterface.h>
+
+class QQmlComponent;
+class MainComponentPlugin : public QObject, public DTK_QUICK_NAMESPACE::DQmlAppMainWindowInterface
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID DQmlAppMainWindowInterface_iid FILE "plugin.json")
+    Q_INTERFACES(DTK_QUICK_NAMESPACE::DQmlAppMainWindowInterface)
+public:
+    MainComponentPlugin(QObject *parent = nullptr);
+    ~MainComponentPlugin() override;
+
+    QUrl mainComponentPath() const override;
+};
+
+#endif // MAINCOMPONENTPLUGIN_H

--- a/tests/apploaderplugindump/maincomponentplugin/plugin.json
+++ b/tests/apploaderplugindump/maincomponentplugin/plugin.json
@@ -1,0 +1,3 @@
+{
+    "appid": "org.deepin.dtkdeclarative.unit-test"
+}

--- a/tests/apploaderplugindump/preloadplugin/CMakeLists.txt
+++ b/tests/apploaderplugindump/preloadplugin/CMakeLists.txt
@@ -1,0 +1,19 @@
+if(EnableQt5)
+    qtquick_compiler_add_resources(PRELOAD_RCC_SOURCES preload.qrc)
+endif()
+if(EnableQt6)
+    qt_add_resources(PRELOAD_RCC_SOURCES preload.qrc)
+endif()
+
+add_library(${PRELOAD_LIB_NAME} SHARED
+    preloadplugin.cpp
+    ${PRELOAD_RCC_SOURCES}
+)
+
+target_link_libraries(${PRELOAD_LIB_NAME} PRIVATE
+    ${LIB_NAME}
+)
+
+set_target_properties(${PRELOAD_LIB_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${APPLOADER_PLUGINDUMP_OUTPUT_DIR}"
+)

--- a/tests/apploaderplugindump/preloadplugin/Preload.qml
+++ b/tests/apploaderplugindump/preloadplugin/Preload.qml
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.11
+import QtQuick.Window 2.0
+import org.deepin.dtk 1.0
+
+ApplicationWindow {
+    id: window
+    visible: true
+    width: 100; height: 100
+
+    DWindow.loadingOverlay: Rectangle {
+        color: palette.window
+    }
+
+    DWindow.overlayExited: Transition {
+        NumberAnimation {
+            properties: "scale"
+            from: 1
+            to: 0
+            easing.type: Easing.InBack
+        }
+    }
+}

--- a/tests/apploaderplugindump/preloadplugin/plugin.json
+++ b/tests/apploaderplugindump/preloadplugin/plugin.json
@@ -1,0 +1,3 @@
+{
+    "appid": "org.deepin.dtkdeclarative.unit-test"
+}

--- a/tests/apploaderplugindump/preloadplugin/preload.qrc
+++ b/tests/apploaderplugindump/preloadplugin/preload.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/apploader">
+        <file>Preload.qml</file>
+    </qresource>
+</RCC>

--- a/tests/apploaderplugindump/preloadplugin/preloadplugin.cpp
+++ b/tests/apploaderplugindump/preloadplugin/preloadplugin.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "preloadplugin.h"
+
+#include <QGuiApplication>
+#include <QUrl>
+
+DQUICK_USE_NAMESPACE
+
+PreloadPlugin::PreloadPlugin(QObject *parent)
+    : QObject(parent)
+{
+
+}
+
+PreloadPlugin::~PreloadPlugin()
+{
+
+}
+
+QUrl PreloadPlugin::preloadComponentPath() const
+{
+    return QUrl("qrc:///apploader/Preload.qml");
+}

--- a/tests/apploaderplugindump/preloadplugin/preloadplugin.h
+++ b/tests/apploaderplugindump/preloadplugin/preloadplugin.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef PRELOADPLUGIN_H
+#define PRELOADPLUGIN_H
+
+#include <dqmlapppreloadinterface.h>
+
+class QQmlComponent;
+class PreloadPlugin : public QObject, public DTK_QUICK_NAMESPACE::DQmlAppPreloadInterface
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID DQmlAppPreloadInterface_iid FILE "plugin.json")
+    Q_INTERFACES(DTK_QUICK_NAMESPACE::DQmlAppPreloadInterface)
+public:
+    PreloadPlugin(QObject *parent = nullptr);
+    ~PreloadPlugin() override;
+
+    virtual QUrl preloadComponentPath() const override;
+};
+
+#endif // PRELOADPLUGIN_H


### PR DESCRIPTION
  Add UT.
  We add a simulator to test the plugin because we can't call
`AppLoader.exec`.