### PR TITLE
chore: Remove some file for recoverage

### DIFF
--- a/tests/test-recoverage.sh
+++ b/tests/test-recoverage.sh
@@ -10,6 +10,8 @@ filter_files=(
  "QtGui/*"
  "QtQml/*"
  "QtQuick/*"
+ "*dquickbusyindicator*"
+ "*dquicksystempalette*"
 )
 
 SHELL_FOLDER=$(dirname $(readlink -f "$0"))


### PR DESCRIPTION
  those files don't need to add UT.
  `dquickbusyindicator` isn't exported.
  `dquicksystempalette` is depprecated.