### PR TITLE
fix: UT failed in qt6

### DIFF
--- a/src/private/dblitframebuffernode.cpp
+++ b/src/private/dblitframebuffernode.cpp
@@ -101,6 +101,9 @@ public:
 
         const qreal scale = m_item->window() ? m_item->window()->effectiveDevicePixelRatio() : 1;
         QRectF sourceRect = matrix()->mapRect(m_rect);
+        if (!sourceRect.isValid())
+            return;
+
         sourceRect.moveTopLeft(sourceRect.topLeft() * scale);
         sourceRect.setSize(sourceRect.size() * scale);
         const QSize textureSize = sourceRect.size().toSize();
@@ -218,6 +221,9 @@ public:
 
         const auto device = p->device();
         QRectF sourceRect = matrix()->mapRect(m_rect);
+        if (!sourceRect.isValid())
+            return;
+
         sourceRect.moveTopLeft(sourceRect.topLeft() * device->devicePixelRatioF());
         sourceRect.setSize(sourceRect.size() * device->devicePixelRatioF());
         const QSize textureSize = sourceRect.size().toSize();

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -28,6 +28,10 @@ if (QQuickWindow::sceneGraphBackend() != "software") \
 if (QQuickWindow::sceneGraphBackend() == "software") \
         GTEST_SKIP_("Only test non `QSGRendererInterface::Software` backend");
 
+#define TEST_QRHI_SKIP() \
+if (TestUtil::isRunningOnRhi()) \
+    GTEST_SKIP_("Only test non RHI Render, Render nodes not yet supported with QRhi");
+
 class EnvGuard {
 public:
     EnvGuard(const char *name, const QString &value)
@@ -263,5 +267,16 @@ namespace TestUtil {
 #endif
 #endif
         return false;
+    }
+
+    inline bool isRunningOnRhi()
+    {
+        static int retval = -1;
+        if (retval == -1) {
+            QuickViewHelper<> helper;
+            helper.requestExposed();
+            retval = QSGRendererInterface::isApiRhiBased(helper.view->rendererInterface()->graphicsApi());
+        }
+        return static_cast<bool>(retval);
     }
 }

--- a/tests/ut_dblitframebuffernode.cpp
+++ b/tests/ut_dblitframebuffernode.cpp
@@ -68,6 +68,8 @@ public:
 
 TEST(ut_DBlitFramebufferNode, properties)
 {
+    TEST_QRHI_SKIP();
+
     TestUtil::registerType<DBlitFramebufferNodeItem>("DBlitFramebufferNodeItem");
     QuickViewHelper<> helper;
     ASSERT_TRUE(helper.load("qrc:/qml/DBlitFramebufferNodeItem.qml"));

--- a/tests/ut_dquickinwindowblur.cpp
+++ b/tests/ut_dquickinwindowblur.cpp
@@ -13,6 +13,8 @@ DQUICK_USE_NAMESPACE
 
 TEST(ut_DQuickInWindowBlur, properties)
 {
+    TEST_QRHI_SKIP();
+
     QuickViewHelper<> helper("qrc:/qml/DQuickInWindowBlur.qml");
     ASSERT_TRUE(helper.object);
 


### PR DESCRIPTION
  QSGRenderNode::matrix() is invalid called in `render()`,
because QSGRenderNode is support in qt 6.2.
  Skipping ut_quickinwindowblur and ut_dblitframebuffernode.