### PR TITLE
fix: Wrong DConfigWrapper's initialized value

### DIFF
--- a/src/private/dconfigwrapper.cpp
+++ b/src/private/dconfigwrapper.cpp
@@ -241,13 +241,8 @@ void DConfigWrapper::componentComplete()
     for (auto iter = properties.begin(); iter != properties.end(); iter++) {
         // it's need to emit signal, because other qml object maybe read the old value
         // when binding the property before the component completed, also it has a performance problem.
-        if (iter.value().isNull()) {
-            // sync backend's value to `Wrapper`
-            mo->setValue(iter.key(), impl->value(iter.key()));
-        } else {
-            // sync Wrapper's value(defined in qml) to backend.
-            setProperty(iter.key(), iter.value());
-        }
+        // sync backend's value to `Wrapper`, we only use Wrapper's value(defined in qml) as fallback value.
+        mo->setValue(iter.key(), impl->value(iter.key(), iter.value()));
     }
 
      // Using QueuedConnection because impl->setValue maybe emit sync signal in `propertyWriteValue`.

--- a/tests/ut_dconfigwrapper.cpp
+++ b/tests/ut_dconfigwrapper.cpp
@@ -90,8 +90,9 @@ TEST_F(ut_DConfigWrapper, setValueByQml)
     EXPECT_EQ(config->property("key2"), "key2");
     EXPECT_EQ(config->value("key2"), "key2");
 
-    EXPECT_EQ(config->property("key3"), "1");
-    EXPECT_EQ(config->value("key3"), "1");
+    // `key3`'s value(defined in qml) is only fallback value instead of current value.
+    EXPECT_EQ(config->property("key3"), "application");
+    EXPECT_EQ(config->value("key3"), "application");
 
     QSignalSpy key3Change(helper.object, SIGNAL(key3Changed()));
     config->metaObject()->invokeMethod(helper.object, "setKey3", Q_ARG(QVariant, QString("2")));


### PR DESCRIPTION
  It introduced in 7b58695d3745a30b91ff29367729ef6dc24f7086
We only use Wrapper's value as fallback value instead of current value. it is different between qt5 with qt6 for `property string key`, in qt5, it's value read in QMetaProperty is false for `isNull`, but it's true in qt6.