### PR TITLE
fix: crash at a nullptr QQuickWindow pointer

### DIFF
--- a/src/private/dblurimagenode_p.h
+++ b/src/private/dblurimagenode_p.h
@@ -17,6 +17,7 @@ QT_BEGIN_NAMESPACE
 class QQuickItem;
 class QSGTexture;
 class QSGPlainTexture;
+class QQuickWindow;
 #ifndef QT_NO_OPENGL
 class QOpenGLShaderProgram;
 class QOpenGLFramebufferObject;
@@ -59,6 +60,7 @@ public:
 
     RenderingFlags flags() const override;
     QRectF rect() const override;
+    void setWindow(QQuickWindow *window);
 
 protected:
     RenderCallback m_renderCallback = nullptr;
@@ -73,6 +75,7 @@ protected:
     QColor m_blendColor = Qt::transparent;
     bool m_disabledOpaqueRendering = false;
     bool m_followMatrixForSource = false;
+    QPointer<QQuickWindow> m_window;
 };
 
 class DSoftwareBlurImageNode : public DSGBlurNode

--- a/src/private/dquickinwindowblur.cpp
+++ b/src/private/dquickinwindowblur.cpp
@@ -154,6 +154,7 @@ QSGNode *DQuickInWindowBlur::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeDa
     DSGBlurNode *blurNode = static_cast<DSGBlurNode*>(node->firstChild());
     Q_ASSERT(blurNode);
     blurNode->setRadius(m_radius);
+    blurNode->setWindow(window());
     const QRectF rect(0, 0, width(), height());
     blurNode->setSourceRect(rect);
     blurNode->setRect(rect);

--- a/tests/ut_dblurimagenode.cpp
+++ b/tests/ut_dblurimagenode.cpp
@@ -67,6 +67,7 @@ protected:
                 blurNode->setOffscreen(false);
                 blurNode->setBlendColor(TestUtil::simpleColor);
                 blurNode->setRadius(10);
+                blurNode->setWindow(window());
                 blurNode->setRect(QRectF(0, 0, 100, 100));
                 blurNode->setSourceRect(QRectF(0, 0, 100, 100));
 


### PR DESCRIPTION
  It sames as the commit 4cf8a6b7ec3ca944d21e4c88831581adb38a0a00
We store window variable of the item to avoid invaild in some step, because render function is working in readerer thread and `window` of the item is in main thread, it maybe is nullptr in sometime, e.g: QQuickItem::setParentItem in QQuickPopup when switching visible.
  We reserve the judgment of `m_item->window()` to reduce the possibility
of errors in render function.
  TODO: QSGNode's render function shouldn't access QQuickItem.

Issue: https://github.com/linuxdeepin/developer-center/issues/5228