### PR TITLE
fix: NavigationTitle is partially obscured

### DIFF
--- a/qt6/src/qml/settings/SettingsDialog.qml
+++ b/qt6/src/qml/settings/SettingsDialog.qml
@@ -50,9 +50,9 @@ DialogWindow {
 
     ScrollView {
         id: contentBg
-        width: control.width - navigationBg.width
         anchors {
             right: parent.right
+            left: navigationBg.right
             top: control.top
         }
         padding: DS.Style.settings.content.margin

--- a/src/qml/settings/SettingsDialog.qml
+++ b/src/qml/settings/SettingsDialog.qml
@@ -50,9 +50,9 @@ DialogWindow {
 
     ScrollView {
         id: contentBg
-        width: control.width - navigationBg.width
         anchors {
             right: parent.right
+            left: navigationBg.right
             top: control.top
         }
         padding: DS.Style.settings.content.margin


### PR DESCRIPTION
  Using anchors to caculate width instead of assigning width

Issue: https://github.com/linuxdeepin/dtk/issues/44
