### PR TITLE
fix: PlaceholderText out of range

### DIFF
--- a/qt6/src/qml/PlaceholderText.qml
+++ b/qt6/src/qml/PlaceholderText.qml
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+import QtQuick
 import QtQuick.Controls 2.4
 import QtQuick.Controls.impl 2.4 as I
 
 I.PlaceholderText {
+    elide: Text.ElideRight
 
 }

--- a/src/qml/PlaceholderText.qml
+++ b/src/qml/PlaceholderText.qml
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Controls.impl 2.4 as I
 
 I.PlaceholderText {
+    elide: Text.ElideRight
 
 }


### PR DESCRIPTION
  Set `elide` to fit to the Text item's width.

Issue: https://github.com/linuxdeepin/dtk/issues/42
