### PR TITLE
fix: DciIcon's size too long

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -15,6 +15,12 @@ DQUICK_BEGIN_NAMESPACE
 
 bool DQuickIconImagePrivate::updateDevicePixelRatio(qreal targetDevicePixelRatio)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    if (!qApp->testAttribute(Qt::AA_UseHighDpiPixmaps)) {
+        devicePixelRatio = 1.0;
+        return true;
+    }
+#endif
     devicePixelRatio = targetDevicePixelRatio > 1.0 ? targetDevicePixelRatio : calculateDevicePixelRatio();
     return true;
 }

--- a/src/private/dquickimageprovider.cpp
+++ b/src/private/dquickimageprovider.cpp
@@ -239,9 +239,13 @@ QImage DQuickDciIconProvider::requestImage(const QString &id, QSize *size, const
     // the boundingSize should typically divide by devicePixelRatio,
     // see Qt::AA_UseHighDpiPixmaps.
     int boundingSize = qMax(requestedSize.width(), requestedSize.height());
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps)) {
         boundingSize = qRound(boundingSize / devicePixelRatio);
     }
+#else
+    boundingSize = qRound(boundingSize / devicePixelRatio);
+#endif
 
     const auto currentTheme = toDciTheme(theme);
     auto currentMode = mode;


### PR DESCRIPTION
  DciIcon's size is too large when app doesn't set AA_UseHighDpiPixmaps,
but pixmap will be blur when factor is greater than 1.0,
so app should set AA_UseHighDpiPixmaps.

Issue: https://github.com/linuxdeepin/developer-center/issues/6246
