### PR TITLE
fix: insecure RUNPATH in arch

### DIFF
--- a/cmake/DtkBuildConfig.cmake
+++ b/cmake/DtkBuildConfig.cmake
@@ -88,6 +88,7 @@ function(dtk_extend_target TARGET)
     set(args_option)
     set(args_single
         EnableCov
+        SkipRPATH
     )
     cmake_parse_arguments(PARSE_ARGV 1 arg "${args_option}" "${args_single}" "${args_multi}")
 
@@ -98,5 +99,10 @@ function(dtk_extend_target TARGET)
             target_compile_options(${TARGET} PRIVATE -fprofile-arcs -ftest-coverage)
         endif()
         target_link_libraries(${TARGET} PRIVATE gcov)
+    endif()
+
+    # skip RUNPATH avoid to `Insecure RUNPATH`
+    if (arg_SkipRPATH)
+        set_target_properties(${TARGET} PROPERTIES SKIP_BUILD_RPATH ${arg_SkipRPATH})
     endif()
 endfunction()

--- a/qt6/src/CMakeLists.txt
+++ b/qt6/src/CMakeLists.txt
@@ -20,7 +20,9 @@ qt_add_qml_module(${LIB_NAME}
 )
 
 dtk_extend_target(${LIB_NAME} EnableCov ${ENABLE_COV})
-dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV})
+dtk_extend_target(${PLUGIN_NAME} EnableCov ${ENABLE_COV}
+    SkipRPATH ON
+)
 
 qt_add_translations(${LIB_NAME}
     TS_FILES ${TS_FILES}

--- a/qt6/src/qml/settings/CMakeLists.txt
+++ b/qt6/src/qml/settings/CMakeLists.txt
@@ -22,7 +22,9 @@ qt_add_qml_module(dtkdeclarativesettingsplugin
         "${PLUGIN_OUTPUT_DIR}/${URI_PATH}/settings"
 )
 
-dtk_extend_target(dtkdeclarativesettingsplugin EnableCov ${ENABLE_COV})
+dtk_extend_target(dtkdeclarativesettingsplugin EnableCov ${ENABLE_COV}
+    SkipRPATH ON
+)
 
 target_link_libraries(dtkdeclarativesettingsplugin
 PRIVATE


### PR DESCRIPTION
  I don't know why RUNPATH is exist when linked ${LIB_NAME}.
so i skip it explicitly.