### PR TITLE
fix: Menu's radius following system

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -607,7 +607,7 @@ QtObject {
 
     property QtObject menu: QtObject {
         property int padding: 10
-        property int radius: 18
+        property int radius: D.DTK.platformTheme.windowRadius < 0 ? 18 : D.DTK.platformTheme.windowRadius
         property int margins: 0
         property int overlap: 1
 

--- a/src/private/dmaskeffectnode.cpp
+++ b/src/private/dmaskeffectnode.cpp
@@ -508,6 +508,8 @@ void OpaqueTextureMaterial::setMaskTexture(QSGTexture *texture)
         m_maskTexture = texture;
         return;
     }
+    if (!texture || !m_maskTexture)
+        return;
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (texture->textureId() == m_maskTexture->textureId())

--- a/src/private/dmaskeffectnode_p.h
+++ b/src/private/dmaskeffectnode_p.h
@@ -27,7 +27,7 @@ public:
     int compare(const QSGMaterial *other) const override;
 
     void setMaskTexture(QSGTexture *texture);
-    QSGTexture *maskTexture() const { return m_maskTexture; }
+    QSGTexture *maskTexture() const { return m_maskTexture.data(); }
 
     void setMaskScale(QVector2D maskScale);
     QVector2D maskScale() const { return m_maskScale; }
@@ -39,7 +39,7 @@ public:
     QVector2D sourceScale() const { return m_sourceScale; }
 
 private:
-    QSGTexture *m_maskTexture = nullptr;
+    QPointer<QSGTexture> m_maskTexture = nullptr;
     QVector2D m_maskScale;
     QVector2D m_maskOffset;
     QVector2D m_sourceScale;

--- a/src/qml/FlowStyle.qml
+++ b/src/qml/FlowStyle.qml
@@ -607,7 +607,7 @@ QtObject {
 
     property QtObject menu: QtObject {
         property int padding: 10
-        property int radius: 18
+        property int radius: D.DTK.platformTheme.windowRadius < 0 ? 18 : D.DTK.platformTheme.windowRadius
         property int margins: 0
         property int overlap: 1
 


### PR DESCRIPTION
  Using platformTheme.windowRadius as Menu's radius,
it fallbacks to origin value when platformTheme invalid.
  Adding nullptr check to avoid that app crashed when radius
is changed.

Issue: https://github.com/linuxdeepin/developer-center/issues/6380
