### PR TITLE
feat: support to override for external caller

### DIFF
--- a/qmlplugin/qmlplugin_plugin.cpp
+++ b/qmlplugin/qmlplugin_plugin.cpp
@@ -105,6 +105,10 @@ inline void dtkRegisterTypeAlias(const char *uri1, const char *uri2, int version
         qmlRegisterType(url, uri2, versionMajor, versionMinor, alias);
 }
 
+inline void dtkRegisterTypeOverridable(const char *uri1, const char *uri2, int versionMajor, int versionMinor, const char *qmlFileName) {
+    dtkRegisterTypeAlias(uri1, uri2, versionMajor, versionMinor, qmlFileName, qmlFileName, "overridable/");
+}
+
 inline void dtkStyleRegisterSingletonType(const char *uri1, const char *uri2, int versionMajor, int versionMinor, const char *qmlName) {
     static QString urlTemplate = QStringLiteral("qrc:/dtk/declarative/qml/style/%1.qml");
     QUrl url(urlTemplate.arg(qmlName));
@@ -152,6 +156,7 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     qmlRegisterModule(styleUri.constData(), 1, 0);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QByteArray implUri;
+    dtkRegisterTypeOverridable(uri, nullptr, 1, 0, "InWindowBlur");
 #else
     // @uri org.deepin.dtk.impl
     const QByteArray implUri = QByteArray(uri).append(".impl");

--- a/qt6/src/CMakeLists.txt
+++ b/qt6/src/CMakeLists.txt
@@ -40,7 +40,7 @@ PRIVATE
     ${LIB_NAME}_sources
 )
 
-file(GLOB QML_RCS dtkdeclarative_qml.qrc)
+file(GLOB QML_RCS dtkdeclarative_qml.qrc dtkdeclarative_overridable_qml.qrc)
 qt_add_resources(RESOURCES
     ${QML_RCS}
     ${ASSETS_RCS}

--- a/qt6/src/dtkdeclarative_overridable_qml.qrc
+++ b/qt6/src/dtkdeclarative_overridable_qml.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/dtk/declarative">
+        <file>qml/overridable/InWindowBlur.qml</file>
+    </qresource>
+</RCC>

--- a/qt6/src/qml/FloatingPanel.qml
+++ b/qt6/src/qml/FloatingPanel.qml
@@ -21,6 +21,7 @@ Control {
     property int blurRadius: DS.Style.floatingPanel.radius
 
     background: D.InWindowBlur {
+        id: blur
         implicitWidth: DS.Style.floatingPanel.width
         implicitHeight: DS.Style.floatingPanel.height
         radius: blurRadius
@@ -29,7 +30,7 @@ Control {
         D.ItemViewport {
             anchors.fill: parent
             fixed: true
-            sourceItem: parent
+            sourceItem: blur.content
             radius: control.radius
             hideSource: false
         }

--- a/qt6/src/qml/overridable/InWindowBlur.qml
+++ b/qt6/src/qml/overridable/InWindowBlur.qml
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.11
+import org.deepin.dtk 1.0 as D
+
+D.InWindowBlurImpl {
+    id: control
+    readonly property Item content: control
+}

--- a/src/private/dquickinwindowblur_p.h
+++ b/src/private/dquickinwindowblur_p.h
@@ -27,7 +27,7 @@ class DQuickInWindowBlur : public QQuickItem
     Q_PROPERTY(qreal radius READ radius WRITE setRadius NOTIFY radiusChanged)
     Q_PROPERTY(bool offscreen READ offscreen WRITE setOffscreen NOTIFY offscreenChanged)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QML_NAMED_ELEMENT(InWindowBlur)
+    QML_NAMED_ELEMENT(InWindowBlurImpl)
 #endif
 
 public:


### PR DESCRIPTION
  Add a InWindowBlur to replace original InWindowBlurImpl.
external caller can intercept it by `QQmlAbstractUrlInterceptor`. e.g:
```
class DtkInterceptor : public QQmlAbstractUrlInterceptor
{
public:
    QUrl intercept(const QUrl &path, DataType type)
    {
        if (path.path().endsWith("overridable/InWindowBlur.qml"))
            return "MyBlur.qml";

        return path;
    }
};
```