### PR TITLE
feat: close popup or menu on window deactivate

### DIFF
--- a/qt6/src/qml/Menu.qml
+++ b/qt6/src/qml/Menu.qml
@@ -11,6 +11,7 @@ import org.deepin.dtk.style 1.0 as DS
 T.Menu {
     id: control
 
+    property bool closeOnInactive: true
     property int maxVisibleItems : DS.Style.arrowListView.maxVisibleItems
     property D.Palette backgroundColor: DS.Style.menu.background
     property var model: control.contentModel
@@ -24,6 +25,7 @@ T.Menu {
         }
         return false
     }
+    readonly property bool active: parent && parent.Window.active
 
     implicitHeight: DS.Style.control.implicitHeight(control)
     implicitWidth: DS.Style.control.implicitWidth(control)
@@ -85,6 +87,12 @@ T.Menu {
             implicitHeight: DS.Style.menu.item.height
             radius: DS.Style.menu.radius
             backgroundColor: control.backgroundColor
+        }
+    }
+
+    onActiveChanged: {
+        if (!active && closeOnInactive) {
+            control.close()
         }
     }
 }

--- a/qt6/src/qml/Popup.qml
+++ b/qt6/src/qml/Popup.qml
@@ -10,6 +10,8 @@ import org.deepin.dtk.style 1.0 as DS
 T.Popup {
     id: control
 
+    property bool closeOnInactive: true
+    readonly property bool active: parent && parent.Window.active
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
 
@@ -21,6 +23,12 @@ T.Popup {
             implicitHeight: DS.Style.popup.height
             implicitWidth: DS.Style.popup.width
             radius: DS.Style.popup.radius
+        }
+    }
+
+    onActiveChanged: {
+        if (!active && closeOnInactive) {
+            control.close()
         }
     }
 }

--- a/src/qml/Menu.qml
+++ b/src/qml/Menu.qml
@@ -11,6 +11,7 @@ import org.deepin.dtk.style 1.0 as DS
 T.Menu {
     id: control
 
+    property bool closeOnInactive: true
     property int maxVisibleItems : DS.Style.arrowListView.maxVisibleItems
     property D.Palette backgroundColor: DS.Style.menu.background
     property var model: control.contentModel
@@ -24,6 +25,7 @@ T.Menu {
         }
         return false
     }
+    readonly property bool active: parent && parent.Window.active
 
     implicitHeight: DS.Style.control.implicitHeight(control)
     implicitWidth: DS.Style.control.implicitWidth(control)
@@ -85,6 +87,12 @@ T.Menu {
             implicitHeight: DS.Style.menu.item.height
             radius: DS.Style.menu.radius
             backgroundColor: control.backgroundColor
+        }
+    }
+
+    onActiveChanged: {
+        if (!active && closeOnInactive) {
+            control.close()
         }
     }
 }

--- a/src/qml/Popup.qml
+++ b/src/qml/Popup.qml
@@ -10,6 +10,8 @@ import org.deepin.dtk.style 1.0 as DS
 T.Popup {
     id: control
 
+    property bool closeOnInactive: true
+    readonly property bool active: parent && parent.Window.active
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
 
@@ -21,6 +23,12 @@ T.Popup {
             implicitHeight: DS.Style.popup.height
             implicitWidth: DS.Style.popup.width
             radius: DS.Style.popup.radius
+        }
+    }
+
+    onActiveChanged: {
+        if (!active && closeOnInactive) {
+            control.close()
         }
     }
 }


### PR DESCRIPTION
When window becomes inactive, there is no need to show popup. Add an option "closeOnInactive" to control if we should close popup when toplevel window becomes inactive. Default is true.

Log: close popup or menu on window deactivate