### PR TITLE
fix: failure passing implicit width

### DIFF
--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -49,7 +49,7 @@ Window {
 
             Item {
                 id: contentLoader
-                Layout.fillWidth: true
+                Layout.preferredWidth: childrenRect.width
                 Layout.preferredHeight: childrenRect.height
                 Layout.leftMargin: DS.Style.dialogWindow.contentHMargin
                 Layout.rightMargin: DS.Style.dialogWindow.contentHMargin

--- a/src/qml/DialogWindow.qml
+++ b/src/qml/DialogWindow.qml
@@ -49,7 +49,7 @@ Window {
 
             Item {
                 id: contentLoader
-                Layout.fillWidth: true
+                Layout.preferredWidth: childrenRect.width
                 Layout.preferredHeight: childrenRect.height
                 Layout.leftMargin: DS.Style.dialogWindow.contentHMargin
                 Layout.rightMargin: DS.Style.dialogWindow.contentHMargin


### PR DESCRIPTION
Cause DialogWindow use a layout with an item to layout children,
children's Layout properties is not directly passed to DialogWindow.
Use children rect's width to set preferredWidth.

Log: fix failure passing implicit width
