### PR TITLE
feat: support base64 format for icons

### DIFF
--- a/examples/qml-inspect/Example_2.qml
+++ b/examples/qml-inspect/Example_2.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.11
 import org.deepin.dtk 1.0
 
 Rectangle {
+    property string iconStr: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAABFCAYAAAAGscunAAAAAXNSR0IArs4c6QAAATNJREFUeF7t3DEOgkAYBeG3J2NvxnIy2JNhKEwUDYyWMJZmLPh8tH+Jn1OBcloYRCQwApH+Rlozgt9eMymZ9g/2uaQ145Ch1dRrIhw81ZIlPX1KSXvNviKNGVt7724BNmVKSxPp6N8WCbwLIokEBEDikkQCAiBxSSIBAZC4JJGAAEhckkhAACQuSSQgABKXJBIQAIlLEgkIgMQliQQEQOKSRAICIHFJIgEBkLgkkYAASFySSEAAJC5JJCAAEpckEhAAiUsSCQiAxCWJBARA4pJEAgIgcUkiAQGQuCSRgABIXJJIQAAkLkkkIAASlyQSEACJSxIJCIDEJYkEBEDikkQCAiBxSSIBAZD8tKSaessLEz09c2ZwPGETX294XuK5tN0Jju1rr96A11AkkYAASFwSQHoAZNuhVXVGph0AAAAASUVORK5CYII="
 
     RowLayout {
         id:row_layout_1
@@ -16,8 +17,19 @@ Rectangle {
         anchors.right: parent.right
 
         QtIcon {
-            name: "button_voice"
+            name: iconStr
             sourceSize: Qt.size(50, 50)
+        }
+
+        DciIcon {
+            name: iconStr
+            sourceSize: Qt.size(50, 50)
+        }
+
+        IconLabel {
+            icon.name: iconStr
+            icon.width: 50
+            icon.height: 50
         }
         QtIcon {
             name: "search_indicator"

--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -27,7 +27,7 @@ DQuickDciIconImageItemPrivate::DQuickDciIconImageItemPrivate(DQuickDciIconImageP
 void DQuickDciIconImageItemPrivate::maybeUpdateUrl()
 {
     Q_Q(DQuickIconImage);
-    if (parentPriv->name.isEmpty()) {
+    if (parentPriv->imageItem->name().isEmpty() || iconType != ThemeIconName) {
         return DQuickIconImagePrivate::maybeUpdateUrl();
     }
 
@@ -41,7 +41,7 @@ void DQuickDciIconImageItemPrivate::maybeUpdateUrl()
 QUrlQuery DQuickDciIconImageItemPrivate::getUrlQuery()
 {
     QUrlQuery query;
-    query.addQueryItem(QLatin1String("name"), parentPriv->name);
+    query.addQueryItem(QLatin1String("name"), parentPriv->imageItem->name());
     query.addQueryItem(QLatin1String("mode"), QString::number(parentPriv->mode));
     query.addQueryItem(QLatin1String("theme"), QString::number(parentPriv->theme));
     query.addQueryItem(QLatin1String("themeName"), QIcon::themeName());
@@ -60,6 +60,7 @@ DQuickDciIconImagePrivate::DQuickDciIconImagePrivate(DQuickDciIconImage *qq)
     : DObjectPrivate(qq)
     , imageItem(new DQuickIconImage(*new DQuickDciIconImageItemPrivate(this), qq))
 {
+    QObject::connect(imageItem, &DQuickIconImage::nameChanged, qq, &DQuickDciIconImage::nameChanged);
 }
 
 void DQuickDciIconImagePrivate::layout()
@@ -88,18 +89,13 @@ DQuickDciIconImage::~DQuickDciIconImage()
 QString DQuickDciIconImage::name() const
 {
     D_DC(DQuickDciIconImage);
-    return d->name;
+    return d->imageItem->name();
 }
 
 void DQuickDciIconImage::setName(const QString &name)
 {
     D_D(DQuickDciIconImage);
-    if (d->name == name)
-        return;
-
-    d->name = name;
-    d->updateImageSourceUrl();
-    Q_EMIT nameChanged();
+    d->imageItem->setName(name);
 }
 
 DQMLGlobalObject::ControlState DQuickDciIconImage::mode() const

--- a/src/private/dquickdciiconimage_p_p.h
+++ b/src/private/dquickdciiconimage_p_p.h
@@ -37,7 +37,6 @@ public:
     void layout();
     void updateImageSourceUrl();
 
-    QString name;
     DDciIconPalette palette;
     DQuickIconImage *imageItem;
     DQMLGlobalObject::ControlState mode = DQMLGlobalObject::NormalState;

--- a/src/private/dquickiconimage_p_p.h
+++ b/src/private/dquickiconimage_p_p.h
@@ -29,6 +29,10 @@ public:
     qreal calculateDevicePixelRatio() const;
     bool updateDevicePixelRatio(qreal targetDevicePixelRatio) override;
 
+    void updateBase64Image();
+
+    static QImage requestImageFromBase64(const QString &name, const QSize &requestedSize, qreal devicePixelRatio);
+
 private:
     QString name;
     DQuickIconImage::State state = DQuickIconImage::State::Off;
@@ -36,6 +40,7 @@ private:
     QColor color;
     QUrl fallbackSource;
 
+protected:
     enum IconType : qint8 {
         ThemeIconName, // 图标名称
         Base64Data, // base64编码的图标图片数据


### PR DESCRIPTION
  We don't use ImageProvider to support base64 image, although it can
use Qt's pixmap cache, the cache will use url as a part of the cache key.
