### PR TITLE
changelog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(DTK_VERSION "5.6.8" CACHE STRING "Define project version")
+set(DTK_VERSION "5.6.23" CACHE STRING "Define project version")
 project(DtkDeclarative
     VERSION "${DTK_VERSION}"
     DESCRIPTION "DTK Declarative module"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+dtkdeclarative (5.6.23) unstable; urgency=medium
+
+  * feat: support to override for external caller
+  * feat: close popup or menu on window deactivate
+  * feat: Optimize flags of RenderNode
+  * fix: failure passing implicit width
+  * chore: enable blur for DialogTitleBar
+  * fix: Multi options selected for Combobox(Issue: https://github.com/linuxdeepin/developer-center/issues/6187)
+  * Revert "fix: failure passing implicit width"
+  * chore: TypeError warning
+  * chore: TypeError warning
+
+ -- YeShanShan <yeshanshan@deepin.org>  Fri, 19 Jan 2024 14:18:56 +0800
+
 dtkdeclarative (5.6.22) unstable; urgency=medium
 
   * fix: no translations for context menu(Issue: https://github.com/linuxdeepin/developer-center/issues/6712)


### PR DESCRIPTION
- chore: remove unnecessary workflows
- feat: Support dpkg-buildpackage for qt6 (#1)
- fix: should be libdtk6core instead of libdtkcore6
- feat: support build archlinux package for qt6
- fix: missing qml package for dpkg
- chore: update changelog to 6.0.1
- fix: missing doxyqml
- fix: wrong install path for plugins
- chore: bump version to 6.0.2
- chore: update depends
- chore: remove dtk-exhibition's desktop in debian
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- chore: bump version to 6.0.3
- sync: from linuxdeepin/dtkdeclarative
- chore: bump version to 6.0.4
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- chore: update changelog
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- sync: from linuxdeepin/dtkdeclarative
- chore: update changelog to 6.0.6
- sync: from linuxdeepin/dtkdeclarative
- chore: update changelog to 6.0.7
