### PR TITLE
chore: keep consistent highlight color in different themes

### DIFF
--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -50,6 +50,11 @@ bool DColor::isTypedColor() const noexcept
     return data.color.type >= VARIANT_COLOR_TYPE_OFFSET;
 }
 
+quint8 DColor::type() const noexcept
+{
+    return data.color.type;
+}
+
 static inline QPalette::ColorRole toPaletteColorRole(quint8 type)
 {
     auto color = static_cast<DColor::Type>(type - VARIANT_COLOR_TYPE_OFFSET);

--- a/src/private/dqmlglobalobject_p.h
+++ b/src/private/dqmlglobalobject_p.h
@@ -63,6 +63,7 @@ public:
 
     [[nodiscard]] bool isValid() const noexcept;
     [[nodiscard]] bool isTypedColor() const noexcept;
+    [[nodiscard]] quint8 type() const noexcept;
 
     bool operator==(const DColor &c) const noexcept;
     bool operator!=(const DColor &c) const noexcept;

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -783,7 +783,9 @@ QColor DQuickControlColorSelector::getColorOf(const DQuickControlPalette *palett
             // create the dark color from the light theme
             targetColor = getColor(palette, DQuickControlPalette::Light, familyIndex, stateIndex);
             // inverse the color to dark
-            shouldInverseColor = true;
+            if (targetColor.type() != DColor::Highlight && targetColor.type() != DColor::HighlightedText) {
+                shouldInverseColor = true;
+            }
         }
     } while (false);
 


### PR DESCRIPTION
don't inverse color when the color type is Highlight or HighlightedText

Log: keep consistent highlight color in dark/light themes