### PR TITLE
fix: incorrect color type

### DIFF
--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -52,6 +52,8 @@ bool DColor::isTypedColor() const noexcept
 
 quint8 DColor::type() const noexcept
 {
+    if (!isTypedColor())
+        return DColor::Invalid;
     return data.color.type;
 }
 


### PR DESCRIPTION
`data.color.type` is only valid when DColor is typed color,
and it also not be initialized.
