### PR TITLE
fix: incorrect color type

### DIFF
--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -54,7 +54,7 @@ quint8 DColor::type() const noexcept
 {
     if (!isTypedColor())
         return DColor::Invalid;
-    return data.color.type;
+    return data.color.type - VARIANT_COLOR_TYPE_OFFSET;
 }
 
 static inline QPalette::ColorRole toPaletteColorRole(quint8 type)


### PR DESCRIPTION
`data.color.type` is equal with `DColor::Type + offset`, so we
should subtract offset.
maybe we should return DColor::Type instead of quint8.

Issue: https://github.com/linuxdeepin/developer-center/issues/6841
