### PR TITLE
refact: export asynchronous property to user

### DIFF
--- a/docs/qml/noqml/dquickdciicon.zh_CN.dox
+++ b/docs/qml/noqml/dquickdciicon.zh_CN.dox
@@ -225,7 +225,9 @@
 
     该属性默认时 false.
 
+@property bool DciIcon::asynchronous
 
+    指定图标是否异步加载，默认异步加载，该属性和Image的asynchronous属性效果一致。
 
 @attachedproperty enumeration DciIcon::mode
 

--- a/docs/qml/noqml/dquickiconimage.zh_CN.dox
+++ b/docs/qml/noqml/dquickiconimage.zh_CN.dox
@@ -5,11 +5,12 @@
 @ingroup Item
 
     \keyword DQuickIconImage
-@brief 提供一种使用 Qt 方式加在图标的控件
+@brief 提供一种使用 Qt 方式加载图标的控件
 
     QtIcon 作为 DTK 程序访问和插件 Qt 图标的控件，虽然 DTK Quick 极力推荐
     应用在大多数的场景下使用 Qt 图标，但是不乏存在应用能需要使用 Qt 图标的情况。
-    因此 DTK 提供 QtIcon 来访问和获取 Qt 图标。 其使用方式如下所示代码：
+    因此 DTK 提供 QtIcon 来访问和获取 Qt 图标（默认使用异步的方式加载）。
+    其使用方式（同步加载）如下所示代码：
 
 @
     QtIcon {
@@ -22,6 +23,7 @@
         mode: QtIcon.Selected
         color: "gray"
         state: QtIcon.On
+        asynchronous: false
     }
 ```
 
@@ -94,4 +96,3 @@
 
     用于当 name 属性无法获取到图标时， fallbackSource 能够提供次选方案。
     如果两种方式都无法找到图标，应用程序将出现一些警告信息。
-

--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -61,6 +61,7 @@ DQuickDciIconImagePrivate::DQuickDciIconImagePrivate(DQuickDciIconImage *qq)
     , imageItem(new DQuickIconImage(*new DQuickDciIconImageItemPrivate(this), qq))
 {
     QObject::connect(imageItem, &DQuickIconImage::nameChanged, qq, &DQuickDciIconImage::nameChanged);
+    QObject::connect(imageItem, &QQuickImage::asynchronousChanged, qq, &DQuickDciIconImage::asynchronousChanged);
 }
 
 void DQuickDciIconImagePrivate::layout()
@@ -190,6 +191,18 @@ void DQuickDciIconImage::setFallbackToQIcon(bool newFallbackToQIcon)
     d->fallbackToQIcon = newFallbackToQIcon;
     Q_EMIT fallbackToQIconChanged();
     d->updateImageSourceUrl();
+}
+
+bool DQuickDciIconImage::asynchronous() const
+{
+    D_DC(DQuickDciIconImage);
+    return d->imageItem->asynchronous();
+}
+
+void DQuickDciIconImage::setAsynchronous(bool async)
+{
+    D_D(DQuickDciIconImage);
+    d->imageItem->setAsynchronous(async);
 }
 
 Dtk::Quick::DQuickIconImage *DQuickDciIconImage::imageItem() const

--- a/src/private/dquickdciiconimage_p.h
+++ b/src/private/dquickdciiconimage_p.h
@@ -30,6 +30,7 @@ class DQuickDciIconImage : public QQuickItem, DCORE_NAMESPACE::DObject
     Q_PROPERTY(QSize sourceSize READ sourceSize WRITE setSourceSize NOTIFY sourceSizeChanged)
     Q_PROPERTY(bool mirror READ mirror WRITE setMirror NOTIFY mirrorChanged)
     Q_PROPERTY(bool fallbackToQIcon READ fallbackToQIcon WRITE setFallbackToQIcon NOTIFY fallbackToQIconChanged)
+    Q_PROPERTY(bool asynchornous READ asynchronous WRITE setAsynchronous NOTIFY asynchronousChanged)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QML_NAMED_ELEMENT(DciIcon)
     QML_ATTACHED(DQuickIconAttached)
@@ -60,6 +61,9 @@ public:
     bool fallbackToQIcon() const;
     void setFallbackToQIcon(bool newFallbackToQIcon);
 
+    bool asynchronous() const;
+    void setAsynchronous(bool async);
+
     DQuickIconImage *imageItem() const;
 
     static bool isNull(const QString &iconName);
@@ -73,6 +77,7 @@ Q_SIGNALS:
     void sourceSizeChanged();
     void mirrorChanged();
     void fallbackToQIconChanged();
+    void asynchronousChanged();
 
 protected:
     void classBegin() override;

--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -147,7 +147,7 @@ qreal DQuickIconImagePrivate::calculateDevicePixelRatio() const
 DQuickIconImage::DQuickIconImage(QQuickItem *parent)
     : QQuickImage(*(new DQuickIconImagePrivate), parent)
 {
-
+    setAsynchronous(true); // asynchronous by default
 }
 
 DQuickIconImage::~DQuickIconImage()

--- a/src/private/dquickimageprovider.cpp
+++ b/src/private/dquickimageprovider.cpp
@@ -125,7 +125,7 @@ static QImage generateDciIconImage(const QImage &src, DDciIcon::Theme theme, DDc
 }
 
 DQuickIconProvider::DQuickIconProvider()
-    : QQuickImageProvider(QQuickImageProvider::Image, QQuickImageProvider::ForceAsynchronousImageLoading)
+    : QQuickImageProvider(QQuickImageProvider::Image)
 {
 
 }
@@ -136,8 +136,7 @@ QImage DQuickIconProvider::requestImage(const QString &id, QSize *size, const QS
 }
 
 DQuickDciIconProvider::DQuickDciIconProvider()
-    : QQuickImageProvider(QQuickImageProvider::Image,
-                          QQuickImageProvider::ForceAsynchronousImageLoading)
+    : QQuickImageProvider(QQuickImageProvider::Image)
 {
 }
 


### PR DESCRIPTION
Use synchronous image providers for icon and dci icon, let user decide when to use asynchronous loading by setAsynchronous property in QtIcon and DciIcon. By default, the loading is asynchronous.

Log: export asynchronous property to user.