### PR TITLE
fix: incorrect text color for MenuItem

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -660,7 +660,6 @@ QtObject {
         property D.Palette itemText: D.Palette {
             normal: ("black")
             normalDark: Qt.rgba(1, 1, 1, 0.6)
-            hovered: D.DTK.makeColor(D.Color.HighlightedText)
         }
 
         property D.Palette separatorText: D.Palette {

--- a/qt6/src/qml/MenuItem.qml
+++ b/qt6/src/qml/MenuItem.qml
@@ -22,7 +22,8 @@ T.MenuItem {
         width: DS.Style.menu.item.iconSize.height
     }
 
-    property D.Palette textColor: DS.Style.menu.itemText
+    property D.Palette textColor: control.highlighted ? DS.Style.checkedButton.text
+                                                      : DS.Style.menu.itemText
     property D.Palette subMenuBackgroundColor: DS.Style.menu.subMenuOpenedBackground
 
     palette.windowText: D.ColorSelector.textColor

--- a/src/qml/FlowStyle.qml
+++ b/src/qml/FlowStyle.qml
@@ -659,7 +659,6 @@ QtObject {
         property D.Palette itemText: D.Palette {
             normal: ("black")
             normalDark: Qt.rgba(1, 1, 1, 0.6)
-            hovered: D.DTK.makeColor(D.Color.HighlightedText)
         }
 
         property D.Palette separatorText: D.Palette {

--- a/src/qml/MenuItem.qml
+++ b/src/qml/MenuItem.qml
@@ -22,7 +22,8 @@ T.MenuItem {
         width: DS.Style.menu.item.iconSize.height
     }
 
-    property D.Palette textColor: DS.Style.menu.itemText
+    property D.Palette textColor: control.highlighted ? DS.Style.checkedButton.text
+                                                      : DS.Style.menu.itemText
     property D.Palette subMenuBackgroundColor: DS.Style.menu.subMenuOpenedBackground
 
     palette.windowText: D.ColorSelector.textColor


### PR DESCRIPTION
windowText color is highlight color when it's highlighted, and
ignore it's hover state.
