### PR TITLE
fix: can't set placeholder text color for SearchEdit

### DIFF
--- a/qt6/src/qml/SearchEdit.qml
+++ b/qt6/src/qml/SearchEdit.qml
@@ -39,7 +39,6 @@ LineEdit {
             Text {
                 id: centerIndicatorLabel
                 text: qsTr("Search")
-                color: palette.text
                 verticalAlignment: Text.AlignVCenter
             }
         }
@@ -82,7 +81,7 @@ LineEdit {
                 }
                 PropertyChanges {
                     target: centerIndicatorLabel
-                    color: palette.text
+                    color: control.placeholderTextColor
                 }
             }
         ]

--- a/src/qml/SearchEdit.qml
+++ b/src/qml/SearchEdit.qml
@@ -39,7 +39,6 @@ LineEdit {
             Text {
                 id: centerIndicatorLabel
                 text: qsTr("Search")
-                color: palette.text
                 verticalAlignment: Text.AlignVCenter
             }
         }
@@ -82,7 +81,7 @@ LineEdit {
                 }
                 PropertyChanges {
                     target: centerIndicatorLabel
-                    color: palette.text
+                    color: control.D.ColorSelector.placeholderTextColor
                 }
             }
         ]


### PR DESCRIPTION
log: centerIndicatorLabel color should follow control.placeholderTextColor