### PR TITLE
fix controltheme

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -469,6 +469,7 @@ void DQuickControlColorSelector::setControl(QQuickItem *newControl)
         connect(m_control, &QQuickItem::visibleChanged, this, &DQuickControlColorSelector::updateControlState);
         connect(m_control, &QQuickItem::windowChanged, this, &DQuickControlColorSelector::updateControlWindow);
         updateControlWindow();
+        updateControlTheme();
 
         if (m_control != parent()) {
             auto csForControl = qobject_cast<DQuickControlColorSelector *>(


### PR DESCRIPTION
- fix: incorrect control themetype for ColorSelector
Issue: https://github.com/linuxdeepin/developer-center/issues/7952