### PR TITLE
fix: duplicate updates of palette

### DIFF
--- a/docs/qml/noqml/dqmlglobalobject.zh_CN.dox
+++ b/docs/qml/noqml/dqmlglobalobject.zh_CN.dox
@@ -306,7 +306,8 @@
     当themeType为UnknownType时, 将自动根据
     GuiApplication::palette的QPalette::background颜色计算主题
     类型, 否则与 paletteType 的值一致. 程序中应当使用此值作为
-    暗色/亮色主题类型的判断.
+    暗色/亮色主题类型的判断. 设置该属性会重新设置palette, 并且会
+    覆盖qml中的属性赋值, 与qml中的属性绑定冲突.
 
 @property int DTK::windowManagerName
 @note 此属性为只读属性

--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -239,7 +239,9 @@ void DQuickWindowAttachedPrivate::_q_updateWindowPalette()
 {
     Q_Q(DQuickWindowAttached);
     auto pt = window->isActive() ? quickPalette : inactiveQuickPalette;
-    QQuickWindowPrivate::get(q->window())->setPalette(pt);
+    // Write qml property to cancle any binding on palette.
+    // NOTE: this is not recoverable, i.e. setting DWindow.themeType will invalidate binding on palette.
+    QQmlProperty::write(q->window(), "palette", QVariant::fromValue(pt));
 }
 #endif
 


### PR DESCRIPTION
When themeType is set, we should remove any binding in qml for property "palette". For example, ApplicationWindow will refresh palette when active changes.

Log: fix duplicate updates of palette
Issue: https://github.com/linuxdeepin/developer-center/issues/7826