### PR TITLE
fix: dci icon not centered

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -63,6 +63,8 @@ DQuickDciIconImagePrivate::DQuickDciIconImagePrivate(DQuickDciIconImage *qq)
     QObject::connect(imageItem, &DQuickIconImage::nameChanged, qq, &DQuickDciIconImage::nameChanged);
     QObject::connect(imageItem, &DQuickIconImage::asynchronousChanged, qq, &DQuickDciIconImage::asynchronousChanged);
     QObject::connect(imageItem, &DQuickIconImage::cacheChanged, qq, &DQuickDciIconImage::cacheChanged);
+    auto dd = QQuickItemPrivate::get(imageItem);
+    dd->anchors()->setAlignWhenCentered(false); // Don't align to a whole pixel, keep it centered.
 }
 
 void DQuickDciIconImagePrivate::layout()


### PR DESCRIPTION
Disable align when centered.

Log: fix dci icon not centered
Issue: https://github.com/linuxdeepin/developer-center/issues/7941