### PR TITLE
chore: incorrect font for SearchEdit's indicator text

### DIFF
--- a/qt6/src/qml/SearchEdit.qml
+++ b/qt6/src/qml/SearchEdit.qml
@@ -39,6 +39,7 @@ LineEdit {
             Text {
                 id: centerIndicatorLabel
                 text: qsTr("Search")
+                font: control.font
                 verticalAlignment: Text.AlignVCenter
             }
         }

--- a/src/qml/SearchEdit.qml
+++ b/src/qml/SearchEdit.qml
@@ -39,6 +39,7 @@ LineEdit {
             Text {
                 id: centerIndicatorLabel
                 text: qsTr("Search")
+                font: control.font
                 verticalAlignment: Text.AlignVCenter
             }
         }


### PR DESCRIPTION
as title.

Issue: https://github.com/linuxdeepin/developer-center/issues/8040
