### PR TITLE
fix: text color of ToolTip doesn't change with theme

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -600,6 +600,10 @@ QtObject {
         property int verticalPadding: 4
         property int horizontalPadding: 5
         property int height: 24
+        property D.Palette text: D.Palette {
+            normal: Qt.rgba(0, 0, 0, 1)
+            normalDark: Qt.rgba(1, 1, 1, 1)
+        }
     }
 
     property QtObject alertToolTip: QtObject {

--- a/qt6/src/qml/ToolTip.qml
+++ b/qt6/src/qml/ToolTip.qml
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-import QtQuick 2.11
+import QtQuick
 import QtQuick.Templates as T
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
@@ -12,6 +12,8 @@ T.ToolTip {
 
     x: parent ? (parent.width - implicitWidth) / 2 : 0
     y: -implicitHeight - 3
+
+    property D.Palette textColor: DS.Style.toolTip.text
 
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
@@ -23,13 +25,14 @@ T.ToolTip {
     closePolicy: T.Popup.CloseOnEscape | T.Popup.CloseOnPressOutsideParent | T.Popup.CloseOnReleaseOutsideParent
 
     contentItem: Text {
+        property alias textColor: control.textColor
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
         text: control.text
         font: control.font
         wrapMode: Text.WordWrap
         opacity: enabled ? 1.0 : 0.4
-        color: control.palette.toolTipText
+        color: D.ColorSelector.textColor
     }
 
     background: FloatingPanel {

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -28,7 +28,8 @@ DQUICK_BEGIN_NAMESPACE
 static inline bool _d_isControlItem(QQuickItem *item) {
 #define _D_FOR_EACH_SIMILAR_CONTROL_ITEM(F) \
     F(QQuickControl), \
-    F(QQuickTextField)
+    F(QQuickTextField), \
+    F(QQuickText)
 
 #if defined(QT_NAMESPACE)
 #define SIMILAR_CONTROL_ITEM_NAMESPACE_STR1(NAME, Item) #NAME "::" #Item
@@ -461,7 +462,9 @@ void DQuickControlColorSelector::setControl(QQuickItem *newControl)
         connect(palette, &QQuickPalette::changed, this, &DQuickControlColorSelector::updateControlTheme);
 #endif
         connect(m_control, SIGNAL(paletteChanged()), this, SLOT(updateControlTheme()));
-        connect(m_control, SIGNAL(hoveredChanged()), this, SLOT(updateControlState()));
+        if (m_control->metaObject()->indexOfSignal("hoveredChanged()") != -1) {
+            connect(m_control, SIGNAL(hoveredChanged()), this, SLOT(updateControlState()));
+        }
         if (m_control->metaObject()->indexOfSignal("pressedChanged()") != -1) {
             connect(m_control, SIGNAL(pressedChanged()), this, SLOT(updateControlState()));
         }


### PR DESCRIPTION
palette.toolTipText doesn't change with theme.
TODO: we should support to use ColorSelector for QQuickItem.

Issue: https://github.com/linuxdeepin/developer-center/issues/8073
