### PR TITLE
fix: icon blurry when half aligned

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -63,8 +63,8 @@ DQuickDciIconImagePrivate::DQuickDciIconImagePrivate(DQuickDciIconImage *qq)
     QObject::connect(imageItem, &DQuickIconImage::nameChanged, qq, &DQuickDciIconImage::nameChanged);
     QObject::connect(imageItem, &DQuickIconImage::asynchronousChanged, qq, &DQuickDciIconImage::asynchronousChanged);
     QObject::connect(imageItem, &DQuickIconImage::cacheChanged, qq, &DQuickDciIconImage::cacheChanged);
-    auto dd = QQuickItemPrivate::get(imageItem);
-    dd->anchors()->setAlignWhenCentered(false); // Don't align to a whole pixel, keep it centered.
+    // auto dd = QQuickItemPrivate::get(imageItem);
+    // dd->anchors()->setAlignWhenCentered(false); // Don't align to a whole pixel, keep it centered.
 }
 
 void DQuickDciIconImagePrivate::layout()
@@ -164,6 +164,8 @@ void DQuickDciIconImage::setSourceSize(const QSize &size)
     D_D(DQuickDciIconImage);
     this->setImplicitWidth(size.width());
     this->setImplicitHeight(size.height());
+    d->imageItem->setWidth(size.width());
+    d->imageItem->setHeight(size.height());
     d->imageItem->setSourceSize(size);
     Q_EMIT sourceSizeChanged();
 }


### PR DESCRIPTION
Don't enable half align. Offset of image item is caused by layout,
when calculating width and height for image item, there is floating
point error compared with sourceSize, thus x and y is not zero.Set
width and height for image item to avoid calculation error of x and y.

Log: fix icon blurry when half aligned
