### PR TITLE
fix: crash at DQuickItemViewport::updatePaintNode

### DIFF
--- a/src/dquickitemviewport.cpp
+++ b/src/dquickitemviewport.cpp
@@ -503,8 +503,7 @@ QSGNode *DQuickItemViewport::updatePaintNode(QSGNode *old, QQuickItem::UpdatePai
             maskNode->setMaskTexture(d->textureForRadiusMask());
             maskNode->setMaskScale(d->getMaskSizeRatio());
         }
-    } else {
-        Q_ASSERT(softwareNode);
+    } else if (softwareNode) {
         softwareNode->setSmooth(smooth());
         softwareNode->setRect(QRectF(QPointF(0, 0), size()));
         softwareNode->setRadius(d->radius);


### PR DESCRIPTION
Don't assert, some source item's texture is null on initialing.