### PR TITLE
fix: DCiicon has aliasing when using base64 data

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -54,7 +54,7 @@ QImage DQuickIconImagePrivate::requestImageFromBase64(const QString &name, const
     } else {
         icon_size /= devicePixelRatio;
     }
-    image = image.scaled(icon_size * devicePixelRatio, Qt::KeepAspectRatio);
+    image = image.scaled(icon_size * devicePixelRatio, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
     return image;
 }


### PR DESCRIPTION
use Qt::SmoothTransformation when scale

Issue: https://github.com/linuxdeepin/developer-center/issues/8941