### PR TITLE
fix: column layout fills the space available

### DIFF
--- a/qt6/src/qml/ControlGroup.qml
+++ b/qt6/src/qml/ControlGroup.qml
@@ -10,7 +10,6 @@ import org.deepin.dtk.style 1.0 as DS
 ColumnLayout {
     id: root
     spacing: 10
-    clip: true
 
     property string title
     property bool isExpanded: true
@@ -143,6 +142,7 @@ ColumnLayout {
 
     ColumnLayout {
         id: itemLayout
+        Layout.fillHeight: false
     }
 
     onIsExpandedChanged: (isExpanded) => {


### PR DESCRIPTION
it's senseless that column layout fills the space available in ControlGroup,
so set Layout.fillHeight to false

Log: