### PR TITLE
fix: the display size of dci icon is exceptional

### DIFF
--- a/qt6/src/qml/ControlGroup.qml
+++ b/qt6/src/qml/ControlGroup.qml
@@ -100,10 +100,12 @@ ColumnLayout {
                 verticalAlignment: Qt.AlignVCenter
             }
             D.DciIcon {
-                Layout.preferredWidth: 36
-                Layout.preferredHeight: 36
                 rotation: root.isExpanded ? 0 : - 90
                 name: "arrow_ordinary_down"
+                mode: title.D.ColorSelector.controlState
+                theme: title.D.ColorSelector.controlTheme
+                palette: D.DTK.makeIconPalette(title.palette)
+                sourceSize: Qt.size(36, 36)
 
                 Behavior on rotation {
                     NumberAnimation {


### PR DESCRIPTION
The size of dci icon becomes larger than before when updating the interface under the dpi > 1.0

Log: