### PR TITLE
fix: Incorrect corner cutting of FloatingPanel

### DIFF
--- a/qt6/src/qml/FloatingPanel.qml
+++ b/qt6/src/qml/FloatingPanel.qml
@@ -49,6 +49,7 @@ Control {
                 radius: control.radius
                 hideSource: false
                 compositionMode: DTK.CompositionMode.Source
+                antialiasing: false
             }
         }
 

--- a/src/private/dquickitemviewport_p.h
+++ b/src/private/dquickitemviewport_p.h
@@ -215,7 +215,7 @@ public:
             QQuickItemPrivate *d = QQuickItemPrivate::get(q_func());
             maskTexture = MaskTextureCache::instance()->getTexture(d->sceneGraphRenderContext(),
                                                                    qRound(radius * d->window->effectiveDevicePixelRatio()),
-                                                                   true);
+                                                                   d->antialiasing);
 
             markDirty(DirtyMaskTexture, false);
         }


### PR DESCRIPTION
When the background is transparent, the first time using ItemViewport to crop rounded corners, anti aliasing is already present, and the second time no longer requires anti aliasing

Issue: https://pms.uniontech.com/bug-view-271399.html