### PR TITLE
feat: Export the alignment property of Combobox

### DIFF
--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -18,6 +18,7 @@ T.ComboBox {
     property bool showAlert
     property int maxVisibleItems : DS.Style.comboBox.maxVisibleItems
     property D.Palette separatorColor: DS.Style.comboBox.edit.separator
+    property var horizontalAlignment: control.flat ? Text.AlignRight : Text.AlignLeft
 
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
@@ -103,6 +104,7 @@ T.ComboBox {
         T.TextField {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.rightMargin: DS.Style.comboBox.spacing
             text: control.editable ? control.editText : control.displayText
 
             enabled: control.editable
@@ -116,6 +118,7 @@ T.ComboBox {
             selectionColor: control.palette.highlight
             selectedTextColor: control.palette.highlightedText
             verticalAlignment: Text.AlignVCenter
+            horizontalAlignment: control.horizontalAlignment
         }
     }
 


### PR DESCRIPTION
If flat is true, it defaults to right alignment

Log: