### PR TITLE
fix: app crashed when when InWindowBlur switching frequently

### DIFF
--- a/src/private/dbackdropnode_p.h
+++ b/src/private/dbackdropnode_p.h
@@ -35,7 +35,7 @@ public:
     typedef void(*TextureChangedNotifer)(DBackdropNode *node, void *data);
     void setTextureChangedCallback(TextureChangedNotifer callback, void *data);
     inline void doNotifyTextureChanged() {
-        if (!m_renderCallback)
+        if (!m_renderCallback || !m_item)
             return;
         m_renderCallback(this, m_callbackData);
     }

--- a/src/private/dquickbackdropblitter.cpp
+++ b/src/private/dquickbackdropblitter.cpp
@@ -276,10 +276,6 @@ QSGNode *DQuickBackdropBlitter::updatePaintNode(QSGNode *oldNode, QQuickItem::Up
 
     node->setContentItem(d->container);
     node->setTextureChangedCallback(onTextureChanged, d);
-    connect(this, &QObject::destroyed, this, [node](){
-        // fix callback crashed...
-        node->setTextureChangedCallback(nullptr, nullptr);
-    });
     node->resize(size());
     onTextureChanged(node, d);
 


### PR DESCRIPTION
updatePaintNode will be executed  multiple times, so it should at least
be a slot function that only connects once, and `node` maybe
a invalid pointer, because QSGNode and QuickItem are managed by
two different threads.
We can use `m_item` to adjust whether the texture is valid, because
it's a QPointer for QQuickItem.
