### PR TITLE
fix: shaders conflicting in qt6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ qt5_add_translation(QM_FILES ${TS_FILES})
 add_library(${LIB_NAME} SHARED
     ${RESOURCES}
     ${QM_FILES}
+    ${PROJECT_SOURCE_DIR}/src/dtkdeclarative_shaders.qrc
 )
 
 dtk_extend_target(${LIB_NAME} EnableCov ${ENABLE_COV})

--- a/src/dtkdeclarative_assets.qrc
+++ b/src/dtkdeclarative_assets.qrc
@@ -1,15 +1,6 @@
 <RCC>
     <qresource prefix="/dtk/declarative">
-        <file>shaders/quickitemviewport.frag</file>
-        <file>shaders/quickitemviewport-opaque.frag</file>
-        <file>shaders/quickitemviewport-opaque.vert</file>
         <file>qml/style/Style.qml</file>
-        <file>shaders/dualkawasedown.frag</file>
-        <file>shaders/dualkawasedown.vert</file>
-        <file>shaders/dualkawaseup.frag</file>
-        <file>shaders/dualkawaseup.vert</file>
-        <file>shaders/noise.vert</file>
-        <file>shaders/noise.frag</file>
         <file>shadow/0.0.0.0.0.4.0.9.png</file>
         <file>shadow/0.4.4.4.4.4.0.17.png</file>
         <file>shadow/0.5.5.5.5.10.1.31.png</file>

--- a/src/dtkdeclarative_shaders.qrc
+++ b/src/dtkdeclarative_shaders.qrc
@@ -1,0 +1,13 @@
+<RCC>
+    <qresource prefix="/dtk/declarative">
+        <file>shaders/quickitemviewport.frag</file>
+        <file>shaders/quickitemviewport-opaque.frag</file>
+        <file>shaders/quickitemviewport-opaque.vert</file>
+        <file>shaders/dualkawasedown.frag</file>
+        <file>shaders/dualkawasedown.vert</file>
+        <file>shaders/dualkawaseup.frag</file>
+        <file>shaders/dualkawaseup.vert</file>
+        <file>shaders/noise.vert</file>
+        <file>shaders/noise.frag</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
dtkdeclarative_asserts is required on qt5 and qt6, but
shaders is separate.
