### PR TITLE
fix: switch button's icon is not found

### DIFF
--- a/src/dtkdeclarative_assets.qrc
+++ b/src/dtkdeclarative_assets.qrc
@@ -46,6 +46,7 @@
         <file alias="built-in-icons/slider_point_left.dci">icons/bloom/slider_point_left.dci</file>
         <file alias="built-in-icons/slider_round_hor.dci">icons/bloom/slider_round_hor.dci</file>
         <file alias="built-in-icons/slider_round_ver.dci">icons/bloom/slider_round_ver.dci</file>
+        <file alias="built-in-icons/switch_button.dci">icons/bloom/switch_button.dci</file>
         <file alias="built-in-icons/switch_on.dci">icons/bloom/switch_on.dci</file>
         <file alias="built-in-icons/switch_off.dci">icons/bloom/switch_off.dci</file>
         <file alias="built-in-icons/slider_point_up.dci">icons/bloom/slider_point_up.dci</file>


### PR DESCRIPTION
add switch button icon to qrc file

Bug: https://pms.uniontech.com/bug-view-276703.html 
Log: