### PR TITLE
fix: StyledBehindWindowBlur crash in render thread

### DIFF
--- a/src/private/dquickbehindwindowblur.cpp
+++ b/src/private/dquickbehindwindowblur.cpp
@@ -32,7 +32,7 @@ protected:
     }
 
     bool m_isRestore = false;
-    DQuickBehindWindowBlur *m_item = nullptr;
+    QPointer<DQuickBehindWindowBlur> m_item = nullptr;
     QMatrix4x4 m_lastMatrix;
     QRegion m_lastClip;
     qreal m_lastRadius = -1;
@@ -47,7 +47,10 @@ DSGBlendNode::DSGBlendNode(bool restore)
 
 void DSGBlendNode::render(const QSGRenderNode::RenderState *state)
 {
-    Q_ASSERT(m_item);
+    // m_item may become invalid when the referred blur behind item get destroyed by a Loader.
+    // Give up rendering in this case.
+    if (!m_item)
+        return;
 
     if (m_isRestore)
         return;


### PR DESCRIPTION
如果StyledBehindWindowBlur位于Loader中，则在Loader变为非活动状态时，可能触发DQuickBehindWindowBlur渲染任务中引用已释放的对象导致程序崩溃。通过使用QPointer修复了这个问题：在m_item为非法时放弃渲染。

Log: