### PR TITLE
fix: Boxshadow displays abnormally in fractional scaling scenarios

### DIFF
--- a/qmlplugin/qmlplugin_plugin.cpp
+++ b/qmlplugin/qmlplugin_plugin.cpp
@@ -28,6 +28,7 @@
 #include "private/dquickarrowboxpath_p.h"
 #include "private/dquickcoloroverlay_p.h"
 #include "private/dquickapploaderitem_p.h"
+#include "private/dquickborderimage_p.h"
 #endif
 
 #include "private/dquickimageprovider_p.h"
@@ -195,6 +196,7 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     dtkRegisterType<DQuickArrowBoxPath>(uri, implUri, 1, 0, "ArrowBoxPath");
     dtkRegisterType<DQuickAppLoaderItem>(uri, implUri, 1, 0, "AppLoader");
     dtkRegisterType<DQuickColorOverlay>(uri, implUri, 1, 0, "SoftwareColorOverlay");
+    dtkRegisterType<DQuickBorderImage>(uri, implUri, 1, 0, "DBorderImage");
 
     dtkRegisterAnonymousType<DQUICK_NAMESPACE::DQuickDciIcon>(uri, implUri, 1);
     dtkRegisterAnonymousType<DQuickControlColor>(uri, implUri, 1);

--- a/qt6/src/qml/BoxShadow.qml
+++ b/qt6/src/qml/BoxShadow.qml
@@ -26,7 +26,7 @@ Item {
     readonly property real __minImageSize: 2 * __borderBase
     readonly property real __boxSize: __minImageSize - 2 * shadowBlur - 2 * __spread + 1
 
-    BorderImage {
+    D.DBorderImage {
         id: image
 
         anchors {

--- a/src/private/dquickborderimage.cpp
+++ b/src/private/dquickborderimage.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dquickborderimage_p.h"
+
+#include <private/qquickitem_p.h>
+#include <private/qquickborderimage_p_p.h>
+
+DQUICK_BEGIN_NAMESPACE
+
+DQuickBorderImage::DQuickBorderImage(QQuickItem *parent)
+    : QQuickBorderImage(parent)
+{
+}
+
+void DQuickBorderImage::itemChange(ItemChange change, const ItemChangeData &value)
+{
+    if (change == ItemDevicePixelRatioHasChanged) {
+        return;
+    }
+
+    QQuickBorderImage::itemChange(change, value);
+}
+
+DQUICK_END_NAMESPACE

--- a/src/private/dquickborderimage_p.h
+++ b/src/private/dquickborderimage_p.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DQUICKBORDERIMAGE_P_H
+#define DQUICKBORDERIMAGE_P_H
+
+#include <dtkdeclarative_global.h>
+
+#include <private/qquickborderimage_p.h>
+
+DQUICK_BEGIN_NAMESPACE
+
+class DQuickBorderImage : public QQuickBorderImage
+{
+    Q_OBJECT
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QML_NAMED_ELEMENT(DBorderImage)
+#endif
+public:
+    explicit DQuickBorderImage(QQuickItem *parent=nullptr);
+
+protected:
+    void itemChange(ItemChange change, const ItemChangeData &value) override;
+};
+
+DQUICK_END_NAMESPACE
+
+#endif // DQUICKBORDERIMAGE_P_H

--- a/src/qml/BoxShadow.qml
+++ b/src/qml/BoxShadow.qml
@@ -26,7 +26,7 @@ Item {
     readonly property real __minImageSize: 2 * __borderBase
     readonly property real __boxSize: __minImageSize - 2 * shadowBlur - 2 * __spread + 1
 
-    BorderImage {
+    D.DBorderImage {
         id: image
 
         anchors {


### PR DESCRIPTION
- Temporary solution