### PR TITLE
fix: combobox does not display content

### DIFF
--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -30,7 +30,7 @@ T.ComboBox {
     delegate: MenuItem {
         useIndicatorPadding: true
         width: control.width
-        text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
+        text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : (model[control.textRole] === undefined ? modelData[control.textRole] : model[control.textRole])) : modelData
         icon.name: (control.iconNameRole && model[control.iconNameRole] !== undefined) ? model[control.iconNameRole] : null
         highlighted: control.highlightedIndex === index
         hoverEnabled: control.hoverEnabled


### PR DESCRIPTION
如果model来自C++的QVarientList，则只能通过modelData[control.textRole]去访问数据

pms: TASK-368711