### PR TITLE
fix: missing QQuickBorderImage symbol fo BoxShadow  in qt5

### DIFF
--- a/qmlplugin/qmlplugin_plugin.cpp
+++ b/qmlplugin/qmlplugin_plugin.cpp
@@ -28,7 +28,6 @@
 #include "private/dquickarrowboxpath_p.h"
 #include "private/dquickcoloroverlay_p.h"
 #include "private/dquickapploaderitem_p.h"
-#include "private/dquickborderimage_p.h"
 #endif
 
 #include "private/dquickimageprovider_p.h"
@@ -196,7 +195,6 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     dtkRegisterType<DQuickArrowBoxPath>(uri, implUri, 1, 0, "ArrowBoxPath");
     dtkRegisterType<DQuickAppLoaderItem>(uri, implUri, 1, 0, "AppLoader");
     dtkRegisterType<DQuickColorOverlay>(uri, implUri, 1, 0, "SoftwareColorOverlay");
-    dtkRegisterType<DQuickBorderImage>(uri, implUri, 1, 0, "DBorderImage");
 
     dtkRegisterAnonymousType<DQUICK_NAMESPACE::DQuickDciIcon>(uri, implUri, 1);
     dtkRegisterAnonymousType<DQuickControlColor>(uri, implUri, 1);

--- a/src/private/dquickborderimage_p.h
+++ b/src/private/dquickborderimage_p.h
@@ -14,9 +14,7 @@ DQUICK_BEGIN_NAMESPACE
 class DQuickBorderImage : public QQuickBorderImage
 {
     Q_OBJECT
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QML_NAMED_ELEMENT(DBorderImage)
-#endif
 public:
     explicit DQuickBorderImage(QQuickItem *parent=nullptr);
 

--- a/src/qml/BoxShadow.qml
+++ b/src/qml/BoxShadow.qml
@@ -26,7 +26,7 @@ Item {
     readonly property real __minImageSize: 2 * __borderBase
     readonly property real __boxSize: __minImageSize - 2 * shadowBlur - 2 * __spread + 1
 
-    D.DBorderImage {
+    BorderImage {
         id: image
 
         anchors {

--- a/src/src.cmake
+++ b/src/src.cmake
@@ -33,10 +33,12 @@ if (EnableDtk5)
     list(REMOVE_ITEM HEADERS
         ${PROJECT_SOURCE_DIR}/src/private/dbackdropnode_p.h
         ${PROJECT_SOURCE_DIR}/src/private/dquickbackdropblitter_p.h
+        ${PROJECT_SOURCE_DIR}/src/private/dquickborderimage_p.h
     )
     list(REMOVE_ITEM SRCS
         ${PROJECT_SOURCE_DIR}/src/private/dbackdropnode.cpp
         ${PROJECT_SOURCE_DIR}/src/private/dquickbackdropblitter.cpp
+        ${PROJECT_SOURCE_DIR}/src/private/dquickborderimage.cpp
     )
 endif()
 


### PR DESCRIPTION
Drop DQuickBorderImage in qt5.

pms: BUG-291539
