### PR TITLE
fix: ColorSelector can't read builtin property firstly in qt6.8

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -861,12 +861,15 @@ void DQuickControlColorSelector::ensureMetaObject()
         return;
 
     m_metaObject = new CustomMetaObject(this);
+    // TODO setCached will cause builtin property is undefined firstly in qml.
+#if QT_VERSION <= QT_VERSION_CHECK(6, 8, 0)
     // Must true, see CustomMetaObject::createProperty
     m_metaObject->setCached(true);
     QQmlData *qmldata = QQmlData::get(this);
     Q_ASSERT(qmldata);
     // the cache object is from QQmlOpenMetaObjectTypePrivate
     m_propertyCache = qmldata->propertyCache;
+#endif
 }
 
 int DQuickControlColorSelector::indexOfPalette(const QByteArray &name) const


### PR DESCRIPTION
Remove cached in qt6.8.

pms: BUG-289241
