### PR TITLE
fix: Do not display AlertToolTip when alertText is empty

### DIFF
--- a/qt6/src/qml/EditPanel.qml
+++ b/qt6/src/qml/EditPanel.qml
@@ -32,7 +32,7 @@ Rectangle {
     }
 
     Loader {
-        active: showAlert
+        active: showAlert && alertText.length !== 0
         sourceComponent: AlertToolTip {
             target: control
             timeout: alertDuration


### PR DESCRIPTION
Do not display AlertToolTip when alertText is empty

Log:
pms: BUG-287159