### PR TITLE
fix: ItemDelegate/Checkdelegate hover background missing

### DIFF
--- a/qt6/src/qml/CheckDelegate.qml
+++ b/qt6/src/qml/CheckDelegate.qml
@@ -72,7 +72,7 @@ T.CheckDelegate {
         implicitHeight: DS.Style.itemDelegate.height
         Rectangle {
             anchors.fill: parent
-            visible: !checked && !control.ListView.view
+            visible: !control.checked && !D.DTK.hasAnimation && control.hovered
             color: control.D.ColorSelector.backgroundColor
             radius: DS.Style.control.radius
         }

--- a/qt6/src/qml/ItemDelegate.qml
+++ b/qt6/src/qml/ItemDelegate.qml
@@ -116,7 +116,7 @@ T.ItemDelegate {
 
         Loader {
             anchors.fill: parent
-            active: !checked && control.normalBackgroundVisible
+            active: !checked && control.normalBackgroundVisible && !D.DTK.hasAnimation && control.hovered
             sourceComponent: D.RoundRectangle {
                 color: DS.Style.itemDelegate.normalColor
                 radius: DS.Style.control.radius


### PR DESCRIPTION
hovered background missing when Dtk.hasAnimation false

pms: Bug-293075