### PR TITLE
fix: icon size not update on dpr changed

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -22,7 +22,12 @@ bool DQuickIconImagePrivate::updateDevicePixelRatio(qreal targetDevicePixelRatio
         return true;
     }
 #endif
+    qreal ratio = devicePixelRatio;
     devicePixelRatio = targetDevicePixelRatio > 1.0 ? targetDevicePixelRatio : calculateDevicePixelRatio();
+
+    if (ratio != devicePixelRatio)
+        maybeUpdateUrl();
+
     return true;
 }
 


### PR DESCRIPTION
qApp.devicePixelRatio != window.effectiveDevicePixelRatio in treeland