### PR TITLE
arrowlistview not clip  &&  lineedit rightpadding to small 

### DIFF
--- a/qt6/src/qml/ArrowListView.qml
+++ b/qt6/src/qml/ArrowListView.qml
@@ -32,6 +32,7 @@ FocusScope {
 
         ListView {
             id: itemsView
+            clip: true
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)

--- a/qt6/src/qml/LineEdit.qml
+++ b/qt6/src/qml/LineEdit.qml
@@ -10,7 +10,7 @@ TextField {
     id: control
     readonly property alias clearButton: clearBtn
 
-    rightPadding: clearBtn.active ? (clearBtn.width + clearBtn.anchors.rightMargin) : 0
+    rightPadding: clearBtn.active ? (clearBtn.width + clearBtn.anchors.rightMargin) : 10
     selectByMouse: true
 
     Loader {

--- a/src/qml/ArrowListView.qml
+++ b/src/qml/ArrowListView.qml
@@ -34,6 +34,7 @@ FocusScope {
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)
+            clip: true
             implicitWidth:{
                 var maxWidth = DS.Style.arrowListView.width
                 if (!itemsView.model || !itemsView.model.hasOwnProperty("get"))

--- a/src/qml/LineEdit.qml
+++ b/src/qml/LineEdit.qml
@@ -10,7 +10,7 @@ TextField {
     id: control
     readonly property alias clearButton: clearBtn
 
-    rightPadding: clearBtn.active ? (clearBtn.width + clearBtn.anchors.rightMargin) : 0
+    rightPadding: clearBtn.active ? (clearBtn.width + clearBtn.anchors.rightMargin) : 10
     selectByMouse: true
 
     Loader {


### PR DESCRIPTION
- fix arrow button and item text overlap 
- lineedit  right padding 0 ==> 10 without clear button

修改前 
![企业微信截图_17344282339829](https://github.com/user-attachments/assets/4e3d8e28-b453-4462-b442-8c6143b16835)
![image](https://github.com/user-attachments/assets/acd0144f-6130-4e1d-861a-d76514e752fa)


修改后
![企业微信截图_17344281859959](https://github.com/user-attachments/assets/d5017cd2-2f92-4831-ba0c-f701880c82dd)
![image](https://github.com/user-attachments/assets/9d83026a-74db-4900-a2d2-343a08bda6d2)

