### PR TITLE
fix: access nullptr when app exited

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -944,9 +944,10 @@ void DQuickControlColorSelector::notifyColorPropertyChanged()
 
 void DQuickControlColorSelector::updatePropertyFromName(const QByteArray &name, const DQuickControlPalette *palette)
 {
+    if (QCoreApplication::closingDown())
+        return;
     auto appriv = dynamic_cast<QCoreApplicationPrivate *>(QObjectPrivate::get(qApp));
-    Q_ASSERT(appriv);
-    if (QCoreApplication::closingDown() || !appriv || appriv->aboutToQuitEmitted)
+    if (!appriv || appriv->aboutToQuitEmitted)
         return;
     Q_ASSERT(!name.isEmpty());
     QColor color;


### PR DESCRIPTION
qApp maybe is nullptr, so we check QCoreApplication::closingDown
before call QObjectPrivate::get(qApp).

pms: TASK-368399
