### PR TITLE
fix: incorrect scaling of icons under Treeland

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -168,6 +168,9 @@ void DQuickDciIconImageItemPrivate::updatePlayer()
 
     player->setPalette(palette);
 
+    // treeland下拿qApp的缩放不准确，初始化的时候尝试去更新一次缩放
+    updateDevicePixelRatio(1.0);
+
     player->setDevicePixelRatio(devicePixelRatio);
 }
 


### PR DESCRIPTION
The scaling obtained from qApp is inaccurate. When the window is updated, the effective scaling is taken from the window

pms: BUG-296965