### PR TITLE
fix: MinimizeButton behavior mismatch with qwidget

### DIFF
--- a/qt6/src/qml/WindowButtonGroup.qml
+++ b/qt6/src/qml/WindowButtonGroup.qml
@@ -26,10 +26,10 @@ RowLayout {
         }
 
         if (Window.window.visibility === Window.Maximized) {
-            Window.window.visibility = Window.Windowed
+            __dwindow.showNormal()
         } else if (Window.window.visibility !== Window.FullScreen &&
                    maxOrWindedBtn.active) {
-            Window.window.visibility = Window.Maximized
+            __dwindow.showMaximized()
         }
     }
 
@@ -45,7 +45,9 @@ RowLayout {
             icon.name: "window_minimize"
             textColor: control.textColor
 
-            onClicked: Window.window.visibility = Window.Minimized
+            onClicked:{
+                __dwindow.showMinimized()
+            }
         }
     }
 
@@ -61,9 +63,9 @@ RowLayout {
 
             onClicked: {
                 if (Window.window.visibility === Window.FullScreen) {
-                    Window.window.visibility = Window.Windowed
+                    __dwindow.showNormal()
                 } else {
-                    Window.window.visibility = Window.FullScreen
+                    __dwindow.showFullScreen()
                 }
             }
         }

--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -543,6 +543,37 @@ void DQuickWindowAttached::setWindowStartUpEffect(DTK_GUI_NAMESPACE::DPlatformHa
         d->explicitEffectType = type;
 }
 
+void DQuickWindowAttached::showMinimized()
+{
+    window()->setWindowStates((window()->windowStates() & ~Qt::WindowActive) | Qt::WindowMinimized);
+    window()->setVisible(true);
+}
+
+void DQuickWindowAttached::showMaximized()
+{
+    window()->setWindowStates((window()->windowStates() & ~(Qt::WindowMinimized | Qt::WindowFullScreen))
+                   | Qt::WindowMaximized);
+    window()->setVisible(true);
+}
+
+void DQuickWindowAttached::showFullScreen()
+{
+    window()->setWindowStates((window()->windowStates() & ~(Qt::WindowMinimized | Qt::WindowMaximized))
+                   | Qt::WindowFullScreen);
+    window()->setVisible(true);
+#if !defined Q_OS_QNX
+    window()->requestActivate();
+#endif
+}
+
+void DQuickWindowAttached::showNormal()
+{
+    window()->setWindowStates(window()->windowStates() & ~(Qt::WindowMinimized
+                                     | Qt::WindowMaximized
+                                     | Qt::WindowFullScreen));
+    window()->setVisible(true);
+}
+
 /*!
  * \~chinese \property DQuickWindowAttached::translucentBackground
  * \~chinese \brief 如果此属性值为 true，则在更新窗口绘制内容之前会先清空要更新区域内的图像，否则不清空。

--- a/src/dquickwindow.h
+++ b/src/dquickwindow.h
@@ -157,6 +157,11 @@ public Q_SLOTS:
     void setWindowEffect(DTK_GUI_NAMESPACE::DPlatformHandle::EffectScenes effect);
     void setWindowStartUpEffect(DTK_GUI_NAMESPACE::DPlatformHandle::EffectTypes type);
 
+    void showMinimized();
+    void showMaximized();
+    void showFullScreen();
+    void showNormal();
+
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
 


### PR DESCRIPTION
It maybe the difference between qml and qwidget.
We can use xwininfo to get _NET_WM_STATE, Window's state is
missing MAXIMIZED state when clicked minimize button for qml app,
but it's exist in qwidget's app.
We refer to qwidget to implement it.

pms:BUG-281185
