### PR TITLE
feat: using DConfig in the non-GUI thread

### DIFF
--- a/src/private/dsettingscontainer.cpp
+++ b/src/private/dsettingscontainer.cpp
@@ -277,7 +277,7 @@ void SettingsOption::setConfig(DConfigWrapper *config)
     if (propertyIndex < 0) {
         connect(m_config, &DConfigWrapper::valueChanged, this, [this](const QString &key){
             if (key == m_key) {
-                setValue(m_config->value(key));
+                setValue(m_config->value(key), false);
                 m_valueInitialized = true;
             }
         });
@@ -305,17 +305,22 @@ SettingsOption *SettingsOption::qmlAttachedProperties(QObject *object)
 
 void SettingsOption::onConfigValueChanged()
 {
-    setValue(m_config->value(m_key));
+    setValue(m_config->value(m_key), false);
     m_valueInitialized = true;
 }
 
 void SettingsOption::setValue(QVariant value)
 {
+    setValue(value, true);
+}
+
+void SettingsOption::setValue(const QVariant &value, bool updateConfig)
+{
     if (value == m_value)
         return;
 
     m_value = value;
-    if (m_config)
+    if (updateConfig && m_config)
         m_config->setValue(m_key, value);
 
     Q_EMIT valueChanged(value);

--- a/src/private/dsettingscontainer_p.h
+++ b/src/private/dsettingscontainer_p.h
@@ -54,6 +54,8 @@ private Q_SLOTS:
     void onConfigValueChanged();
 
 private:
+    void setValue(const QVariant &value, bool updateConfig);
+
     QString m_key;
     QString m_name;
     QVariant m_value;

--- a/tests/qml/Config.qml
+++ b/tests/qml/Config.qml
@@ -12,6 +12,7 @@ Item {
         id: exampleConfig
         name: "example"
         subpath: ""
+        async: false
         property string key2
         property string key3 : "1"
         onKey3Changed: control.key3Changed()

--- a/tests/ut_dconfigwrapper.cpp
+++ b/tests/ut_dconfigwrapper.cpp
@@ -38,6 +38,7 @@ TEST_F(ut_DConfigWrapper, componentComplete)
 {
     QScopedPointer<DConfigWrapper> config(new DConfigWrapper());
 
+    config->setAsync(false);
     config->classBegin();
     config->setName("example");
     config->setSubpath("");
@@ -50,6 +51,7 @@ TEST_F(ut_DConfigWrapper, setValue)
 {
     QScopedPointer<DConfigWrapper> config(new DConfigWrapper());
 
+    config->setAsync(false);
     config->classBegin();
     config->setName("example");
     config->componentComplete();


### PR DESCRIPTION
The DConfig is a sync IO API, call it's API maybe block the GUI thread on the DConfigWrapper, so we need use the DConfig in a new thread.