### PR TITLE
fix: incorrect width for Menu

### DIFF
--- a/qt6/src/qml/Menu.qml
+++ b/qt6/src/qml/Menu.qml
@@ -45,11 +45,12 @@ T.Menu {
 
     contentItem: FocusScope {
         // QTBUG-99897 focus doesn't be clear.
-        implicitWidth: viewLayout.width
-        implicitHeight: viewLayout.height
+        implicitWidth: viewLayout.implicitWidth
+        implicitHeight: viewLayout.implicitHeight
         ColumnLayout {
             id: viewLayout
             spacing: 0
+            anchors.fill: parent
 
             Loader {
                 Layout.fillWidth: true


### PR DESCRIPTION
Using implicitWidth instead of width of ColumnLayout, and
filling it's parent for ColumnLayout.

pms: BUG-303357 BUG-302791
