### PR TITLE
chore: replacing a way to get listview's item

### DIFF
--- a/qt6/src/qml/ArrowListView.qml
+++ b/qt6/src/qml/ArrowListView.qml
@@ -38,11 +38,8 @@ FocusScope {
             implicitHeight: Math.min(contentHeight, maxVisibleItems * itemHeight)
             implicitWidth:{
                 var maxWidth = DS.Style.arrowListView.width
-                if (!itemsView.model || !itemsView.model.hasOwnProperty("get"))
-                    return maxWidth
-
                 for (var i = 0; i < itemsView.count; ++i) {
-                    var item = itemsView.model.get(i)
+                    var item = itemsView.itemAtIndex(i)
                     if (item && item.implicitWidth > maxWidth)
                         maxWidth = item.implicitWidth
                 }

--- a/qt6/src/qml/Menu.qml
+++ b/qt6/src/qml/Menu.qml
@@ -67,19 +67,6 @@ T.Menu {
                 view.currentIndex: control.currentIndex
                 maxVisibleItems: control.maxVisibleItems
                 itemHeight: DS.Style.menu.item.height
-
-                function refreshContentItemWidth()
-                {
-                    for (var i = 0; i < view.count; ++i) {
-                        var item = view.model.get(i)
-                        if (item) {
-                            item.width = view.width
-                        }
-                    }
-                }
-
-                onCountChanged: refreshContentItemWidth()
-                onWidthChanged: refreshContentItemWidth()
                 view.highlightFollowsCurrentItem: true
                 view.highlightMoveDuration: 50
                 view.highlightMoveVelocity: -1


### PR DESCRIPTION
it's useful for combobox to fillWidth  by max'width.

pms: TASK-368399

## Summary by Sourcery

Enhancements:
- Improve the `ArrowListView` component by replacing the usage of `view.model.get(i)` with `view.itemAtIndex(i)` to access items, which is necessary for comboboxes to fill width by max width.