### PR TITLE
fix: double click doesn't work for TitleBar

### DIFF
--- a/qt6/src/qml/DialogTitleBar.qml
+++ b/qt6/src/qml/DialogTitleBar.qml
@@ -23,19 +23,14 @@ Item {
 
     property var __dwindow: Window.window.D.DWindow
 
-    MouseArea {
-        anchors.fill: parent
-        acceptedButtons: Qt.AllButtons
-        propagateComposedEvents: true
-        onPressed: function(mouse) {
-            if (mouse.button === Qt.RightButton) {
-                if (mouse.x < control.width - closeBtn.width) {
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: function (eventPoint, button) {
+            if (button === Qt.RightButton) {
+                if (eventPoint.position.x < control.width - closeBtn.width) {
                     __dwindow.popupSystemWindowMenu()
-                    mouse.accepted = true
-                    return
                 }
             }
-            mouse.accepted = false
         }
     }
 


### PR DESCRIPTION
Using TabHandler instead of MouseArea to deal with event.
Control eat MouseEvent by default action, so we replace it with
Item.
Reserving 1 pix to watching hover event.

pms: BUG-303843

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where double-clicking on the TitleBar was not working as expected.