### PR TITLE
fix: StyledBehindWindowBlur crash in render thread

### DIFF
--- a/src/private/dquickbehindwindowblur.cpp
+++ b/src/private/dquickbehindwindowblur.cpp
@@ -49,7 +49,7 @@ void DSGBlendNode::render(const QSGRenderNode::RenderState *state)
 {
     // m_item may become invalid when the referred blur behind item get destroyed by a Loader.
     // Give up rendering in this case.
-    if (!m_item)
+    if (!m_item || !m_item->window())
         return;
 
     if (m_isRestore)


### PR DESCRIPTION
as title.

pms: TASK-368399

## Summary by Sourcery

Bug Fixes:
- Fixes a crash in the render thread that could occur when the blur behind item is destroyed by a Loader by checking if the window is valid before rendering.