### PR TITLE
fix: Popup background does not follow the theme changes

### DIFF
--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -156,6 +156,7 @@ T.ComboBox {
     }
 
     popup: Popup {
+        palette: control.palette
         implicitWidth: control.width
         contentItem: ArrowListView {
             clip: true


### PR DESCRIPTION
Popup requires manual specification of palette, refer to the Property Promotion section of https://doc.qt.io/qt-6/qml-qtquick-controls-popup.html

pms: BUG-304027

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the Popup background did not follow theme changes.