### PR TITLE
fix: missing FocusBorder for WindowButton in TitleBar

### DIFF
--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -52,8 +52,9 @@ Item {
     palette.windowText: D.ColorSelector.textColor
 
     HoverHandler {
-        enabled: __isFullScreen && autoHideOnFullscreen
         id: hoverHandler
+        // reset it's parent to disable HoverHandler
+        parent: __isFullScreen && autoHideOnFullscreen ? control : null
     }
     TapHandler {
         acceptedButtons: Qt.RightButton | Qt.LeftButton

--- a/qt6/src/qml/WindowButton.qml
+++ b/qt6/src/qml/WindowButton.qml
@@ -6,34 +6,53 @@ import QtQuick
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
 
-Control {
+D.IconButton {
     id: control
-    property alias icon: iconLoader
-    readonly property bool pressed: mouseArea.pressed
-    signal clicked(var mouse)
-    property D.Palette textColor: DS.Style.button.text
-    property D.Palette backgroundColor: DS.Style.windowButton.background
 
-    palette.windowText: D.ColorSelector.textColor
-    hoverEnabled: true
-    contentItem: D.DciIcon {
-        id: iconLoader
-        palette: D.DTK.makeIconPalette(control.palette)
-        sourceSize {
-            width: DS.Style.windowButton.width
-            height: DS.Style.windowButton.height
+    property int topRightRadius: (Window.window.visibility !== Window.Maximized &&
+                                 Window.window.visibility !== Window.FullScreen &&
+                                 isOnRightEdgeOfWindow) ? D.DTK.platformTheme.windowRadius : 0
+    readonly property bool isOnRightEdgeOfWindow: __itemGlobalPoint.x + control.width >= Window.window.width
+
+    readonly property var __itemGlobalPoint: {
+        var a = control
+        var x = 0, y = 0
+        while(a.parent) {
+            x += a.x
+            y += a.y
+            a = a.parent
         }
-        mode: control.D.ColorSelector.controlState
-        theme: control.D.ColorSelector.controlTheme
+        return Qt.point(x, y)
     }
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        Component.onCompleted: clicked.connect(control.clicked)
+
+    topPadding: 0
+    bottomPadding: 0
+    leftPadding: 0
+    rightPadding: 0
+    icon {
+        width: DS.Style.windowButton.width
+        height: DS.Style.windowButton.height
     }
-    background: Rectangle {
+    background: D.BoxPanel {
         implicitWidth: DS.Style.windowButton.width
         implicitHeight: DS.Style.windowButton.height
-        color: control.D.ColorSelector.backgroundColor
+        insideBorderColor: null
+        outsideBorderColor: null
+        color1: DS.Style.windowButton.background
+        color2: color1
+        radius: 0
+
+        Loader {
+            anchors.fill: parent
+            active: control.visualFocus
+            sourceComponent: Rectangle {
+                topRightRadius: control.topRightRadius
+                color: "transparent"
+                border {
+                    width: DS.Style.control.focusBorderWidth
+                    color: control.palette.highlight
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Refacting WindowButton, and use IconButton instead of Control
to display the icon, support topRightRadiusfor last WindowButton.
Fix missing hovered state for Controls in TitleBar.

pms: TASK-368399

## Summary by Sourcery

Refactors WindowButton to use IconButton instead of Control, adds support for topRightRadius for the last WindowButton, and fixes a missing focus border for WindowButton in TitleBar.

Enhancements:
- Refactor WindowButton to use IconButton instead of Control.
- Add support for topRightRadius for the last WindowButton.
- The HoverHandler is disabled when not in fullscreen mode.