### PR TITLE
Supports dconfig2cpp generate class in SettingsDialog

### DIFF
--- a/qt6/src/qml/settings/SettingsDialog.qml
+++ b/qt6/src/qml/settings/SettingsDialog.qml
@@ -12,7 +12,7 @@ DialogWindow {
     id: control
 
     property list<Settings.SettingsGroup> groups
-    property D.Config config
+    property QtObject config
     property Settings.SettingsContainer container : Settings.SettingsContainer {
         id: settingsContainer
         config: control.config

--- a/src/private/dconfigwrapper.cpp
+++ b/src/private/dconfigwrapper.cpp
@@ -363,9 +363,11 @@ void DConfigWrapper::initializeProperties() const
             // Must fallback to the initial value, in the sync mode, the DConfigWrapperMetaObject's
             // properties is not initialize.
             const auto value = impl->value(key, initialValue);
-            callInGuiThread(wrapper, [wrapper, key, value] {
-                if (value.isValid())
+            callInGuiThread(wrapper, [wrapper, key, value, currentValue] {
+                if (value.isValid() && value != currentValue) {
                     wrapper->mo->setValue(key.toLocal8Bit(), value);
+                    Q_EMIT wrapper->valueChanged(key, value);
+                }
             });
         }
     }
@@ -387,8 +389,8 @@ void DConfigWrapper::initializeProperties() const
                 wrapper->mo->setValue(propName, value);
         });
 
-        QMetaObject::invokeMethod(wrapper, [wrapper, key] {
-            Q_EMIT wrapper->valueChanged(key);
+        QMetaObject::invokeMethod(wrapper, [wrapper, key, value] {
+            Q_EMIT wrapper->valueChanged(key, value);
         });
     }, Qt::DirectConnection);
 

--- a/src/private/dconfigwrapper_p.h
+++ b/src/private/dconfigwrapper_p.h
@@ -47,7 +47,7 @@ public Q_SLOTS:
     bool isDefaultValue(const QString &key) const;
 
 Q_SIGNALS:
-    void valueChanged(const QString &key);
+    void valueChanged(const QString &key, const QVariant &value);
     void initialized();
 
 private:

--- a/src/private/dsettingscontainer_p.h
+++ b/src/private/dsettingscontainer_p.h
@@ -10,7 +10,6 @@
 #include <QQmlParserStatus>
 #include <QQmlComponent>
 #include <private/qqmlobjectmodel_p.h>
-#include "dconfigwrapper_p.h"
 
 DQUICK_BEGIN_NAMESPACE
 
@@ -40,7 +39,7 @@ public:
 
     QQmlComponent *delegate() const;
     void setDelegate(QQmlComponent *delegate);
-    void setConfig(DConfigWrapper *config);
+    void setConfig(QObject *config);
 
     static SettingsOption *qmlAttachedProperties(QObject *object);
 
@@ -52,6 +51,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void onConfigValueChanged();
+    void onValueChanged(const QString &key, const QVariant &value);
 
 private:
     void setValue(const QVariant &value, bool updateConfig);
@@ -61,7 +61,7 @@ private:
     QVariant m_value;
     bool m_valueInitialized = false;
     QQmlComponent *m_delegate = nullptr;
-    DConfigWrapper *m_config = nullptr;
+    QObject *m_config = nullptr;
 };
 
 class SettingsGroup : public QObject
@@ -97,7 +97,7 @@ public:
     QQmlListProperty<DTK_QUICK_NAMESPACE::SettingsGroup> children();
     QQmlComponent *background() const;
     void setBackground(QQmlComponent *background);
-    void setConfig(DConfigWrapper *config);
+    void setConfig(QObject *config);
     SettingsGroup *parentGroup() const;
     void setParentGroup(SettingsGroup *parentGroup);
     int index() const;
@@ -190,7 +190,7 @@ class SettingsContainer : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-    Q_PROPERTY(DConfigWrapper *config READ config WRITE setConfig NOTIFY configChanged)
+    Q_PROPERTY(QObject *config READ config WRITE setConfig NOTIFY configChanged)
     Q_PROPERTY(QQmlListProperty<DTK_QUICK_NAMESPACE::SettingsGroup> groups READ groups NOTIFY groupsChanged)
     Q_PROPERTY(SettingsContentModel *contentModel READ contentModel NOTIFY contentModelChanged)
     Q_PROPERTY(QQmlComponent *contentTitle READ contentTitle WRITE setContentTitle NOTIFY contentTitleChanged)
@@ -206,8 +206,8 @@ public:
     explicit SettingsContainer(QObject *parent = nullptr);
     virtual ~SettingsContainer() override;
 
-    DConfigWrapper *config() const;
-    void setConfig(DConfigWrapper *config);
+    QObject *config() const;
+    void setConfig(QObject *config);
     QQmlListProperty<DTK_QUICK_NAMESPACE::SettingsGroup> groups();
     SettingsContentModel *contentModel() const;
     SettingsNavigationModel *navigationModel() const;
@@ -248,7 +248,7 @@ private:
     QQmlComponent *m_contentTitle = nullptr;
     QQmlComponent *m_navigationTitle = nullptr;
     QQmlComponent * m_contentBackground = nullptr;
-    DConfigWrapper *m_config = nullptr;
+    QObject *m_config = nullptr;
 };
 
 DQUICK_END_NAMESPACE

--- a/src/qml/settings/SettingsDialog.qml
+++ b/src/qml/settings/SettingsDialog.qml
@@ -12,7 +12,7 @@ DialogWindow {
     id: control
 
     property list<Settings.SettingsGroup> groups
-    property D.Config config
+    property QtObject config
     property Settings.SettingsContainer container : Settings.SettingsContainer {
         id: settingsContainer
         config: control.config


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refactor SettingsOption to use QObject::property and QObject::setProperty instead of DConfigWrapper::value and DConfigWrapper::setValue.