### PR TITLE
fix: ScrollBar don't display when size is less

### DIFF
--- a/qt6/src/qml/ScrollBar.qml
+++ b/qt6/src/qml/ScrollBar.qml
@@ -14,7 +14,7 @@ T.ScrollBar {
     implicitHeight: DS.Style.control.implicitHeight(control)
 
     padding: DS.Style.scrollBar.padding
-    visible: control.policy !== T.ScrollBar.AlwaysOff
+    visible: control.policy !== T.ScrollBar.AlwaysOff && control.size < 1.0
     policy: D.DTK.platformTheme.scrollBarPolicy
 
     state: "hide"


### PR DESCRIPTION
it's consistent with dtkwidget.

pms: BUG-299771

## Summary by Sourcery

Bug Fixes:
- Ensure ScrollBar is only displayed when the content is scrollable (size is less than 1.0)