### PR TITLE
fix: incorrect padding for MenuItem

### DIFF
--- a/qt6/src/qml/MenuItem.qml
+++ b/qt6/src/qml/MenuItem.qml
@@ -34,8 +34,8 @@ T.MenuItem {
         readonly property real arrowPadding: control.subMenu && control.arrow ? control.arrow.width + control.spacing : 0
         readonly property real indicatorPadding: control.useIndicatorPadding && control.indicator ? control.indicator.width + control.spacing : 0
 
-        leftPadding: (!control.mirrored ? indicatorPadding : arrowPadding) + DS.Style.menu.item.contentPadding
-        rightPadding: (control.mirrored ? indicatorPadding : arrowPadding) + DS.Style.menu.item.contentPadding
+        leftPadding: !control.mirrored ? Math.max(DS.Style.menu.item.contentPadding, indicatorPadding) : arrowPadding
+        rightPadding: control.mirrored ? Math.max(DS.Style.menu.item.contentPadding, indicatorPadding) : arrowPadding
         spacing: control.spacing
         mirrored: control.mirrored
         display: control.display


### PR DESCRIPTION
MenuItem display is incomplete because padding is too enough.

pms: TASK-368399

## Summary by Sourcery

Bug Fixes:
- Correct the padding logic for menu items to properly handle cases with indicators and submenus, ensuring consistent content positioning