### PR TITLE
fix: update image source URL when source size changes

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -296,6 +296,7 @@ void DQuickDciIconImage::setSourceSize(const QSize &size)
 {
     D_D(DQuickDciIconImage);
     d->imageItem->setSourceSize(size);
+    d->updateImageSourceUrl();
     Q_EMIT sourceSizeChanged();
 }
 


### PR DESCRIPTION
1. Added call to updateImageSourceUrl() when setSourceSize() is called
2. Ensures the image URL is properly updated when the source size
changes
3. Fixes potential issue where image wouldn't refresh after size change
4. Maintains consistency between source size and displayed image

fix: 在源尺寸变化时更新图像源URL

1. 在setSourceSize()被调用时添加了updateImageSourceUrl()的调用
2. 确保当源尺寸变化时图像URL能正确更新
3. 修复了尺寸变化后图像可能不会刷新的问题
4. 保持源尺寸和显示图像之间的一致性

pms: BUG-315703

## Summary by Sourcery

Bug Fixes:
- Call updateImageSourceUrl when source size changes to fix cases where the image wouldn’t refresh