### PR TITLE
fix: correct icon image update logic

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -226,7 +226,7 @@ void DQuickIconImage::setName(const QString &name)
     }
 
     if (isComponentComplete()) {
-        d->init();
+        d->maybeUpdateUrl();
     }
 }
 


### PR DESCRIPTION
1. Changed from direct init() call to maybeUpdateUrl() when name is set
2. This ensures proper URL update handling when the icon name changes
3. Fixes potential cases where icon wouldn't update correctly after
name change
4. Maintains consistency with the component's update behavior

fix: 修正图标图片更新逻辑

1. 将直接调用 init() 改为调用 maybeUpdateUrl() 当名称被设置时
2. 确保当图标名称改变时能正确处理URL更新
3. 修复了名称改变后图标可能无法正确更新的情况
4. 保持与组件更新行为的一致性

pms: BUG-311021

## Summary by Sourcery

Bug Fixes:
- Use maybeUpdateUrl() instead of init() in DQuickIconImage::setName to ensure proper URL updates when the icon name changes.