### PR TITLE
fix: use applicationDisplayName instead of qAppName in DQMLGlobalObject

### DIFF
--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -500,7 +500,7 @@ void DQMLGlobalObject::closeMessage(QObject *target, const QString &msgId)
 void DQMLGlobalObject::sendSystemMessage(const QString &summary, const QString &body, const QString &appIcon, const QStringList &actions, const QVariantMap hints, const int timeout, const uint replaceId)
 {
     QDBusPendingCall reply = DTK_CORE_NAMESPACE::DUtil::DNotifySender(summary)
-            .appName(qAppName())
+            .appName(qApp->applicationDisplayName())
             .appIcon(appIcon)
             .appBody(body)
             .actions(actions)


### PR DESCRIPTION
Changed qAppName() to qApp->applicationDisplayName() when sending system
notifications to use the display name rather than the executable name.
This provides better user experience as display names are typically
more readable and user-friendly than raw executable names. The change
affects the notification sender configuration in DQMLGlobalObject's
sendSystemMessage method.

fix: 在DQMLGlobalObject中使用applicationDisplayName替代qAppName

将发送系统通知时的qAppName()改为qApp->applicationDisplayName()，以
使用显示名称而非可执行文件名。这提供了更好的用户体验，因为显示名称通
常比原始可执行文件名更易读和用户友好。此修改影响了DQMLGlobalObject的
sendSystemMessage方法中的通知发送器配置。

## Summary by Sourcery

Enhancements:
- Switch system notification sender to use qApp->applicationDisplayName() instead of qAppName()