### PR TITLE
fix: remove redundant devicePixelRatio division in icon scaling

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -56,8 +56,6 @@ QImage DQuickIconImagePrivate::requestImageFromBase64(const QString &name, const
     QSize icon_size = requestedSize;
     if (icon_size.isEmpty()) {
         icon_size = image.size();
-    } else {
-        icon_size /= devicePixelRatio;
     }
     image = image.scaled(icon_size * devicePixelRatio, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 


### PR DESCRIPTION
The change removes an unnecessary division by devicePixelRatio when scaling icons. The division was redundant because:
1. The image is already being scaled by multiplying with devicePixelRatio in the next line
2. Keeping both operations would effectively cancel each other out
3. This simplifies the logic while maintaining the same visual result

The modification ensures cleaner code without changing the actual behavior, as the final scaled image size remains correct.

fix: 移除图标缩放中多余的 devicePixelRatio 除法操作

本次修改移除了图标缩放过程中多余的 devicePixelRatio 除法运算，因为：
1. 下一行代码已经通过乘以 devicePixelRatio 进行图像缩放
2. 同时保留两个操作会相互抵消效果
3. 简化逻辑的同时保持相同的视觉效果

base64的requestedSize是没有被缩放的原始size，不能除缩放

pms: BUG-304699

## Summary by Sourcery

Bug Fixes:
- Remove redundant devicePixelRatio division in icon scaling