### PR TITLE
chore: remove warning

### DIFF
--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -39,7 +39,7 @@ Item {
 
     property var __dwindow: Window.window.D.DWindow
     property bool __isFullScreen: Window.window.visibility === Window.FullScreen
-    property bool __isVisible: hoverHandler.hovered
+    property alias __isVisible: hoverHandler.hovered
     readonly property int __includedAreaX: control.width - optionMenuBtn.width - windowButtonsLoader.width
 
     property alias enableInWindowBlendBlur: background.active


### PR DESCRIPTION
Cannot read property 'hovered' of null

## Summary by Sourcery

Bug Fixes:
- Prevent 'Cannot read property "hovered" of null' warning by changing __isVisible to a property alias instead of a boolean property