### PR TITLE
feat: add ScrollView component and update TextArea sizing

### DIFF
--- a/chameleon/CMakeLists.txt
+++ b/chameleon/CMakeLists.txt
@@ -35,6 +35,7 @@ set(QML_FILES
     RadioButton.qml
     RoundButton.qml
     ScrollBar.qml
+    ScrollView.qml
     ScrollIndicator.qml
     Slider.qml
     SpinBox.qml

--- a/chameleon/ScrollView.qml
+++ b/chameleon/ScrollView.qml
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import org.deepin.dtk 1.0 as D
+
+D.ScrollView {
+
+}
+

--- a/chameleon/qml.qrc
+++ b/chameleon/qml.qrc
@@ -23,6 +23,7 @@
     <file>RadioButton.qml</file>
     <file>RoundButton.qml</file>
     <file>ScrollBar.qml</file>
+    <file>ScrollView.qml</file>
     <file>ScrollIndicator.qml</file>
     <file>Slider.qml</file>
     <file>SpinBox.qml</file>

--- a/qmlplugin/qmlplugin_plugin.cpp
+++ b/qmlplugin/qmlplugin_plugin.cpp
@@ -254,6 +254,7 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     dtkRegisterType(uri, controlsUri, 1, 0, "ScrollIndicator");
     dtkRegisterType(uri, controlsUri, 1, 0, "Popup");
     dtkRegisterType(uri, controlsUri, 1, 0, "ScrollBar");
+    dtkRegisterType(uri, controlsUri, 1, 0, "ScrollView");
     // DTK Controls
     dtkRegisterType(uri, controlsUri, 1, 0, "LineEdit");
     dtkRegisterType(uri, controlsUri, 1, 0, "SearchEdit");

--- a/qt6/src/qml/ScrollView.qml
+++ b/qt6/src/qml/ScrollView.qml
@@ -2,8 +2,32 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-import QtQuick.Controls
+import QtQuick
+import QtQuick.Controls.impl
+import QtQuick.Templates as T
+import org.deepin.dtk 1.0 as D
 
-ScrollView {
+T.ScrollView {
+    id: control
 
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            contentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             contentHeight + topPadding + bottomPadding)
+
+    D.ScrollBar.vertical: D.ScrollBar {
+        parent: control
+        x: control.mirrored ? 0 : control.width - width
+        y: control.topPadding
+        height: control.availableHeight
+        active: control.D.ScrollBar.horizontal.active
+    }
+
+    D.ScrollBar.horizontal: D.ScrollBar {
+        parent: control
+        x: control.leftPadding
+        y: control.height - height
+        width: control.availableWidth
+        active: control.D.ScrollBar.vertical.active
+    }
 }

--- a/qt6/src/qml/TextArea.qml
+++ b/qt6/src/qml/TextArea.qml
@@ -13,9 +13,13 @@ T.TextArea {
 
     property D.Palette placeholderTextPalette: DS.Style.edit.placeholderText
     placeholderTextColor: D.ColorSelector.placeholderTextPalette
-    implicitWidth: Math.max(DS.Style.control.implicitWidth(control), placeholder.implicitWidth + leftPadding + rightPadding)
-    implicitHeight: Math.max(DS.Style.control.implicitHeight(control), placeholder.implicitHeight + topPadding + bottomPadding)
-
+    implicitWidth: Math.max(contentWidth + leftPadding + rightPadding,
+                            implicitBackgroundWidth + leftInset + rightInset,
+                            placeholder.implicitWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(contentHeight + topPadding + bottomPadding,
+                             implicitBackgroundHeight + topInset + bottomInset,
+                             placeholder.implicitHeight + topPadding + bottomPadding)
+                             
     padding: DS.Style.control.padding
 
     color: palette.text


### PR DESCRIPTION
1. Added new ScrollView.qml component to chameleon and qt6 directories
2. Registered ScrollView type in qmlplugin
3. Updated TextArea.qml to improve implicit width/height calculations
4. ScrollView includes custom ScrollBar implementations for vertical and
horizontal scrolling
5. Changes ensure consistent scrolling behavior and better text area
sizing

The additions provide a dedicated ScrollView component with Deepin DTK
styling and proper scroll bar integration. The TextArea sizing updates
make it more responsive to content changes while maintaining proper
padding and insets.

feat: 添加 ScrollView 组件并更新 TextArea 尺寸计算

1. 在 chameleon 和 qt6 目录中添加新的 ScrollView.qml 组件
2. 在 qmlplugin 中注册 ScrollView 类型
3. 更新 TextArea.qml 以改进隐式宽度/高度计算
4. ScrollView 包含垂直和水平滚动的自定义滚动条实现
5. 这些变更确保了一致的滚动行为和更好的文本区域尺寸计算

这些新增内容提供了具有 Deepin DTK 样式的专用 ScrollView 组件和适当的滚动
条集成。TextArea 尺寸更新使其对内容变化更加敏感，同时保持适当的填充和内
边距。

## Summary by Sourcery

Add a ScrollView QML component with custom Deepin DTK scrollbars and update TextArea implicit sizing to better accommodate content and insets.

New Features:
- Introduce a ScrollView QML component featuring integrated vertical and horizontal DTK scrollbars

Enhancements:
- Enhance TextArea implicit width/height calculations to consider content dimensions, background insets, and placeholder sizing

Build:
- Include ScrollView.qml in chameleon resources and register the ScrollView type in the QML plugin