### PR TITLE
fix: ensure dynamic width binding in QML preview

### DIFF
--- a/examples/exhibition/ViewQMLSource.qml
+++ b/examples/exhibition/ViewQMLSource.qml
@@ -54,7 +54,7 @@ ColumnLayout {
                         var obj = Qt.createQmlObject(edit.text, codePreview,  url.toString().replace(".qml", "_temporary.qml"))
                         globalObject.replace(lastPreview, obj)
                         lastPreview = obj
-                        obj.width = codePreview.width
+                        obj.width = Qt.binding(function () { return codePreview.width })
                         errorMessage.text = ""
                     } catch (error) {
                         errorMessage.text = String(error.lineNumber ? error.lineNumber : "未知") + "行，"


### PR DESCRIPTION
1. Changed static width assignment to dynamic binding using Qt.binding
2. The preview now automatically adjusts when container width changes
3. Fixes issue where preview wouldn't resize with window
4. Maintains better visual consistency during runtime adjustments

fix: 修复 QML 预览中的动态宽度绑定问题

1. 将静态宽度分配改为使用 Qt.binding 的动态绑定
2. 预览现在会在容器宽度变化时自动调整
3. 修复了预览不会随窗口调整大小的问题
4. 在运行时调整时保持更好的视觉一致性

## Summary by Sourcery

Use Qt.binding for dynamic width assignment in QML preview to ensure it automatically resizes with its container and maintains visual consistency.

Bug Fixes:
- Fix preview not resizing when container or window width changes.

Enhancements:
- Replace static width assignment with Qt.binding dynamic binding for the code preview element.