### PR TITLE
style: improve TitleBar layout implementation

### DIFF
--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -12,9 +12,7 @@ Item {
     id: control
     z: D.DTK.TopOrder
     width: Window.window.width
-    // it's binding `height` instead of `visible` property,
-    // because MouseArea should accept event keeping visible.
-    implicitHeight: (!__isFullScreen || __isVisible) ? DS.Style.titleBar.height : 1
+    height: (!__isFullScreen || __isVisible) ? DS.Style.titleBar.height : 1
 
     property string title: Window.window.title
     property alias icon: iconLabel
@@ -75,15 +73,16 @@ Item {
     Loader {
         id: background
         active: false
-        anchors.fill: parent
+        width: control.width
+        height: control.height
         sourceComponent: D.InWindowBlur {
         }
     }
 
     ColumnLayout {
-        id: content
         spacing: 0
-        anchors.fill: parent
+        width: control.width
+        height: control.height
         visible: control.height > 1
 
         Loader {


### PR DESCRIPTION
1. Changed `implicitHeight` to `height` for more explicit sizing control
2. Modified background and content layouts to use explicit width/height
instead of anchors.fill
3. These changes provide better layout consistency and prevent potential
anchoring issues
4. The visibility logic remains the same but is now more clearly
implemented

style: 改进 TitleBar 布局实现

1. 将 `implicitHeight` 改为 `height` 以获得更明确的尺寸控制
2. 修改背景和内容布局使用显式宽高而非 anchors.fill
3. 这些改动提供了更好的布局一致性并防止潜在的锚定问题
4. 可见性逻辑保持不变但实现更清晰

## Summary by Sourcery

Improve TitleBar layout by using explicit width and height properties instead of anchors and implicit sizing to enhance consistency and prevent anchoring issues.

Enhancements:
- Switch TitleBar’s implicitHeight property to explicit height for clearer sizing control
- Replace anchors.fill with explicit width and height on background and content loaders
- Clarify visibility logic while preserving existing behavior to improve layout consistency