### PR TITLE
fix: adjust blur behavior in floating panel and menu

### DIFF
--- a/qt6/src/qml/FloatingPanel.qml
+++ b/qt6/src/qml/FloatingPanel.qml
@@ -22,6 +22,7 @@ Control {
     property int blurRadius: 64
     // blur blurMultiplier
     property real blurMultiplier: 0.0
+    property alias enableBlur: blur.valid
 
     background: D.InWindowBlur {
         id: blur
@@ -41,7 +42,7 @@ Control {
 
         Loader {
             anchors.fill: parent
-            active: Window.window && Window.window.color.a < 1
+            active: Window.window && Window.window.color.a < 1 && blur.valid
             sourceComponent: D.ItemViewport {
                 anchors.fill: parent
                 fixed: true

--- a/qt6/src/qml/Menu.qml
+++ b/qt6/src/qml/Menu.qml
@@ -109,6 +109,7 @@ T.Menu {
             backgroundColor: control.backgroundColor
             backgroundNoBlurColor: control.backgroundNoBlurColor
             outsideBorderColor: null
+            enableBlur: false // TODO disable blur temporarily, pms:BUG 300055
         }
     }
 

--- a/qt6/src/qml/overridable/InWindowBlur.qml
+++ b/qt6/src/qml/overridable/InWindowBlur.qml
@@ -13,7 +13,7 @@ Item {
     property alias multiplier: blur.blurMultiplier
     property alias content: blur
     default property alias data: blitter.data
-    readonly property bool valid: blitter.blitterEnabled
+    property alias valid: blitter.blitterEnabled
 
     D.BackdropBlitter {
         id: blitter


### PR DESCRIPTION
1. Added enableBlur property alias to control blur effect validity
2. Modified Loader activation condition to check both window
transparency and blur validity
3. Temporarily disabled blur in Menu component due to bug 300055
4. Changed InWindowBlur's valid property from readonly to writable for
better control
5. These changes provide more granular control over blur effects and fix
visual issues

fix: 调整浮动面板和菜单的模糊效果行为

1. 添加enableBlur属性别名以控制模糊效果有效性
2. 修改Loader激活条件以同时检查窗口透明度和模糊有效性
3. 由于BUG 300055暂时禁用菜单组件中的模糊效果
4. 将InWindowBlur的valid属性从只读改为可写以便更好控制
5. 这些变更提供了对模糊效果更精细的控制并修复了视觉问题

pms: BUG-300055
