### PR TITLE
style: add normalDark property to alertBackground palette

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -444,6 +444,7 @@ QtObject {
 
         property D.Palette alertBackground: D.Palette {
             normal: Qt.rgba(0.95, 0.22, 0.20, 0.15)
+            normalDark: normal
         }
 
         property D.Palette placeholderText: D.Palette {


### PR DESCRIPTION
Added normalDark property to alertBackground palette in FlowStyle.qml to
ensure consistent dark mode behavior by reusing the same color value as
normal mode. This maintains visual consistency while properly supporting
dark theme implementations where separate dark mode colors aren't needed
for this specific case.

style: 为 alertBackground 调色板添加 normalDark 属性

在 FlowStyle.qml 中为 alertBackground 调色板添加了 normalDark 属性，通
过重用与普通模式相同的颜色值来确保暗黑模式行为的一致性。这保持了视觉一致
性，同时正确支持了不需要为此特定情况单独设置暗黑模式颜色的主题实现。

pms:BUG-321547

## Summary by Sourcery

Enhancements:
- Add normalDark property to alertBackground palette to reuse the normal color in dark mode