### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string


### PR DESCRIPTION
1. Changed the 'version' input parameter from required to optional in
the GitHub Actions workflow
2. This provides more flexibility when triggering releases, allowing for
cases where version might be determined programmatically or isn't needed
3. Maintains backward compatibility while reducing strict requirements

fix: 在发布工作流中将版本参数设为可选

1. 将 GitHub Actions 工作流中的 'version' 输入参数从必填改为可选
2. 这为触发发布提供了更大的灵活性，适用于版本可能通过程序确定或不需要的
情况
3. 在减少严格限制的同时保持了向后兼容性

## Summary by Sourcery

CI:
- Make 'version' input parameter optional in the release workflow