### PR TITLE
fix: add palette to ToolTip component

### DIFF
--- a/qt6/src/qml/ToolTip.qml
+++ b/qt6/src/qml/ToolTip.qml
@@ -21,6 +21,7 @@ T.ToolTip {
     leftPadding: DS.Style.toolTip.horizontalPadding
     rightPadding: leftPadding
     closePolicy: T.Popup.CloseOnEscape | T.Popup.CloseOnPressOutsideParent | T.Popup.CloseOnReleaseOutsideParent
+    palette: D.DTK.palette
 
     contentItem: Text {
         horizontalAlignment: Text.AlignLeft


### PR DESCRIPTION
Added palette property to ToolTip.qml to ensure consistent styling with
DTK theme
The palette was missing which could cause visual inconsistencies with
the rest of the application
Using D.DTK.palette ensures the tooltip follows the application's color
scheme

fix: 为 ToolTip 组件添加调色板属性

在 ToolTip.qml 中添加了 palette 属性以确保与 DTK 主题的样式一致
之前缺少此属性可能导致与应用程序其他部分的视觉不一致
使用 D.DTK.palette 确保工具提示遵循应用程序的色彩方案
