### PR TITLE
feat: add theme-aware progress bar background color

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -504,6 +504,7 @@ QtObject {
             }
 
             property D.Palette shadowInner2: D.Palette {
+                normal: Qt.rgba(0, 0, 0, 0.1)
                 normalDark: Qt.rgba(1, 1, 1, 0.1)
             }
 
@@ -850,6 +851,11 @@ QtObject {
         property D.Palette handleGradientColor:  D.Palette {
             normal: D.DTK.makeColor(D.Color.Highlight).hue(-0).saturation(+30).lightness(+30)
         }
+
+        property D.Palette background: D.Palette {
+            normal: Qt.rgba(0, 0, 0, 0.1)
+            normalDark: Qt.rgba(1, 1, 1, 0.1)
+        }
     }
 
     property QtObject embeddedProgressBar: QtObject {
@@ -861,7 +867,7 @@ QtObject {
 
         property D.Palette background: D.Palette {
             normal: Qt.rgba(0, 0, 0, 0.7)
-            normalDark: Qt.rgba(0, 0, 0, 0.2)
+            normalDark: Qt.rgba(1, 1, 1, 0.2)
         }
 
         property D.Palette progressBackground: D.Palette {

--- a/qt6/src/qml/private/ProgressBarPanel.qml
+++ b/qt6/src/qml/private/ProgressBarPanel.qml
@@ -23,8 +23,9 @@ Item {
     Component {
         id: _normalTextComponent
         Rectangle {
+            property Palette backgroundColor: DS.Style.progressBar.background
             radius: DS.Style.control.radius
-            color: Qt.rgba(0, 0, 0, 0.1);
+            color: ColorSelector.backgroundColor
         }
     }
 }


### PR DESCRIPTION
1. Added background color property to progressBar style in FlowStyle.qml
2. Modified ProgressBarPanel.qml to use theme-aware background color
3. Implemented separate colors for normal and dark themes (rgba values)
4. Uses ColorSelector for dynamic theme switching support

The changes ensure progress bar background colors properly adapt to both
light and dark themes, improving visual consistency across different
theme settings. The implementation provides better theming support by
using the DTK color system.

feat: 添加主题感知的进度条背景色

1. 在FlowStyle.qml中为progressBar样式添加背景色属性
2. 修改ProgressBarPanel.qml以使用主题感知的背景色
3. 为普通和暗色主题实现不同的颜色值(rgba)
4. 使用ColorSelector支持动态主题切换

这些更改确保进度条背景色能正确适配亮色和暗色主题，提升不同主题设置下的视
觉一致性。该实现通过使用DTK颜色系统提供了更好的主题支持。

pms: BUG-320479

## Summary by Sourcery

Add theme-aware background color support to progress bars by defining a background property in FlowStyle.qml, specifying distinct RGBA values for light and dark themes, and applying it in ProgressBarPanel.qml with ColorSelector for dynamic theme switching.

New Features:
- Add theme-aware background property to progressBar style in FlowStyle.qml
- Use DS.Style.progressBar.background in ProgressBarPanel.qml for progress bar backgrounds

Enhancements:
- Define separate RGBA values for light (normal) and dark (normalDark) themes
- Leverage ColorSelector for dynamic theme switching