### PR TITLE
fix: correct arrow list view button behavior

### DIFF
--- a/qt6/src/qml/private/ArrowListViewButton.qml
+++ b/qt6/src/qml/private/ArrowListViewButton.qml
@@ -12,13 +12,13 @@ Loader {
         DownButton = 1
     }
 
-    property Item view
+    required property Item view
     property int direction
     active: view.interactive
 
     sourceComponent: Button {
         flat: true
-        enabled: direction === ArrowListViewButton.UpButton ? !view.atYBeginning : !itemsView.atYEnd
+        enabled: direction === ArrowListViewButton.UpButton ? !view.atYBeginning : !view.atYEnd
         width: DS.Style.arrowListView.stepButtonSize.width
         height: DS.Style.arrowListView.stepButtonSize.height
         icon.name: direction === ArrowListViewButton.UpButton ? DS.Style.arrowListView.upButtonIconName


### PR DESCRIPTION
1. Changed `itemsView.atYEnd` to `view.atYEnd` to fix incorrect button
enabling logic
2. Made `view` property required to ensure proper component
initialization
3. The bug caused arrow buttons to remain enabled incorrectly when
scrolling to the end of the list
4. Required property ensures view reference is always provided for
proper functionality

fix: 修复箭头列表视图按钮行为问题

1. 将 `itemsView.atYEnd` 改为 `view.atYEnd` 以修复按钮启用逻辑错误
2. 将 `view` 属性设为必需以确保组件正确初始化
3. 原错误导致滚动到列表末尾时箭头按钮仍错误地保持启用状态
4. 必需属性确保始终提供视图引用以保证功能正常

## Summary by Sourcery

Fix arrow list view button behavior by requiring the view reference and correcting end-of-list enabling logic

Bug Fixes:
- Correct the down arrow button enabling logic by using view.atYEnd instead of itemsView.atYEnd
- Prevent arrow buttons from remaining enabled when scrolling to the end of the list

Enhancements:
- Make the view property required to ensure proper component initialization