### PR TITLE
fix: correct dark theme color for warning button

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -350,6 +350,7 @@ QtObject {
     property QtObject warningButton: QtObject {
         property D.Palette text: D.Palette {
             normal: ("#ff5736")
+            normalDark: normal
         }
     }
 


### PR DESCRIPTION
Added normalDark property to warningButton text palette to match normal
color in dark theme
Previously the dark theme variant was missing, causing display issues
This ensures consistent warning button appearance across both light and
dark themes

fix: 修正警告按钮在暗色主题下的颜色问题

为警告按钮文本调色板添加normalDark属性以匹配正常颜色
之前缺少暗色主题变体导致显示问题
现在确保警告按钮在明暗主题下外观一致

pms: BUG-327377
