### PR TITLE
feat: add smooth property support for DciIconImage

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -209,6 +209,7 @@ DQuickDciIconImage::DQuickDciIconImage(QQuickItem *parent)
     D_D(DQuickDciIconImage);
     connect(d->imageItem, &QQuickImage::implicitWidthChanged, this, [this, d]() { setImplicitWidth(d->imageItem->implicitWidth()); });
     connect(d->imageItem, &QQuickImage::implicitHeightChanged, this, [this, d]() { setImplicitHeight(d->imageItem->implicitHeight()); });
+    connect(this, &DQuickDciIconImage::smoothChanged, d->imageItem, &QQuickImage::setSmooth);
 }
 
 DQuickDciIconImage::~DQuickDciIconImage()
@@ -392,6 +393,7 @@ void DQuickDciIconImage::classBegin()
     D_D(DQuickDciIconImage);
     QQmlEngine::setContextForObject(d->imageItem, QQmlEngine::contextForObject(this));
     QQuickItem::classBegin();
+    d->imageItem->setSmooth(smooth());
 }
 
 void DQuickDciIconImage::componentComplete()


### PR DESCRIPTION
1. Connect smooth property change signal from DQuickDciIconImage to
QQuickImage
2. Initialize QQuickImage's smooth property during classBegin
3. Ensure smooth property synchronization between DQuickDciIconImage and
internal QQuickImage

Log: Added smooth property support for DciIconImage

Influence:
1. Test smooth property propagation to underlying QQuickImage
2. Verify smooth property initialization during component creation
3. Check smooth property changes during runtime

feat: 为DciIconImage添加smooth属性支持

1. 将DQuickDciIconImage的smooth属性变化信号连接到QQuickImage
2. 在classBegin阶段初始化QQuickImage的smooth属性
3. 确保DQuickDciIconImage和内部QQuickImage的smooth属性同步

Log: 新增DciIconImage的smooth属性支持

Influence:
1. 测试smooth属性是否正确传递到底层QQuickImage
2. 验证组件创建时smooth属性的初始化
3. 检查运行时smooth属性的变化效果

PMS: BUG-327609

## Summary by Sourcery

New Features:
- Add smooth property support for DciIconImage by connecting smoothChanged to the internal QQuickImage and initializing it during classBegin to keep them in sync