### PR TITLE
fix: prevent icon blur by rounding alignment positions

### DIFF
--- a/src/private/dquickiconlabel.cpp
+++ b/src/private/dquickiconlabel.cpp
@@ -208,13 +208,13 @@ static QRectF alignedRect(bool mirrored, Qt::Alignment alignment, const QSizeF &
     const qreal w = size.width();
     const qreal h = size.height();
     if ((alignment & Qt::AlignVCenter) == Qt::AlignVCenter)
-        y += rectangle.height() / 2 - h / 2;
+        y += std::round(rectangle.height() / 2 - h / 2);
     else if ((alignment & Qt::AlignBottom) == Qt::AlignBottom)
         y += rectangle.height() - h;
     if ((alignment & Qt::AlignRight) == Qt::AlignRight)
         x += rectangle.width() - w;
     else if ((alignment & Qt::AlignHCenter) == Qt::AlignHCenter)
-        x += rectangle.width() / 2 - w / 2;
+        x += std::round(rectangle.width() / 2 - w / 2);
     return QRectF(x, y, w, h);
 }
 


### PR DESCRIPTION
Fixed blurry icon rendering issue by applying std::round to center
alignment calculations. When calculating vertical and horizontal center
positions for icons, floating point arithmetic was causing sub-pixel
misalignment which resulted in blurry rendering. The change ensures
pixel-perfect alignment by rounding the calculated positions to nearest
integer values.

Log: Fixed blurry icon rendering when centered in containers

Influence:
1. Verify icons appear sharp when centered in containers
2. Test with various icon sizes and container dimensions
3. Check alignment in both horizontal and vertical directions
4. Verify no regression in other alignment modes (left/right/top/bottom)

fix: 修复图标模糊问题通过四舍五入对齐位置

通过使用std::round对居中对齐计算进行四舍五入处理，修复了图标渲染模糊的
问题。原先计算图标垂直和水平居中位置时，浮点运算会导致亚像素级的错位，从
而造成渲染模糊。此修改通过将计算位置四舍五入到最近的整数值，确保像素完美
对齐。

Log: 修复了图标在容器中居中时出现的模糊问题

Influence:
1. 验证图标在容器中居中时显示清晰
2. 测试不同图标尺寸和容器大小的情况
3. 检查水平和垂直方向的对齐效果
4. 验证其他对齐模式(左/右/上/下)没有出现回归问题

pms: BUG-288427

## Summary by Sourcery

Bug Fixes:
- Apply std::round to horizontal and vertical center position calculations to eliminate sub-pixel misalignment and icon blurring