### PR TITLE
fix: prevent icon blurring during scaling

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -66,10 +66,10 @@ void DQuickIconImagePrivate::init()
 {
     D_Q(DQuickIconImage);
 
-    if (iconType == ThemeIconName) {
-        // 强制确保图标的缩放比例正确
-        updateDevicePixelRatio(1.0);
+    // 强制确保图标的缩放比例正确
+    updateDevicePixelRatio(1.0);
 
+    if (iconType == ThemeIconName) {
         QObject::connect(DGuiApplicationHelper::instance()->applicationTheme(), SIGNAL(iconThemeNameChanged(QByteArray)),
                          q, SLOT(maybeUpdateUrl()));
         // dtk build-in 类型的图标支持区分窗口主题色, 此处需在主题类型变化时更新图标
@@ -372,10 +372,8 @@ void DQuickIconImage::pixmapChange()
     // QQuickImage中只会在设置了souceSize的前提下才会计算图片自身的缩放比例
     // 此处强制确保图标的缩放比例正确
     D_D(DQuickIconImage);
-    if (d->iconType == DQuickIconImagePrivate::ThemeIconName) {
-        if (d->updateDevicePixelRatio(1.0)) {
-            d->maybeUpdateUrl();
-        }
+    if (d->updateDevicePixelRatio(1.0)) {
+        d->maybeUpdateUrl();
     }
 
     QQuickImage::pixmapChange();


### PR DESCRIPTION
The changes modify how device pixel ratio updates are handled for icons
to prevent blurring issues. Previously, the pixel ratio update was only
applied to theme icons, but now it's applied universally to all icon
types before checking the specific icon type. This ensures consistent
scaling behavior across all icon types.

The updateDevicePixelRatio call was moved outside the ThemeIconName
condition check in both initialization and pixmapChange methods. This
guarantees that all icons receive proper scaling treatment regardless
of their type, fixing the blurring issue that occurred during scaling
operations.

Log: Fixed icon blurring issues during scaling operations

Influence:
1. Test icon rendering at various zoom levels
2. Verify theme icons display clearly after scaling
3. Check non-theme icons for clarity after scaling
4. Test icon appearance across different DPI settings

fix: 修复缩放导致的图标模糊问题

修改了图标设备像素比更新的处理方式以防止模糊问题。原先像素比更新仅应用于
主题图标，现在会在检查特定图标类型前统一应用于所有图标类型。这确保了所有
图标类型都能获得一致的缩放行为。

将updateDevicePixelRatio调用从ThemeIconName条件检查中移出，在初始化和
pixmapChange方法中都进行了此修改。这保证了所有图标都能获得适当的缩放处
理，修复了缩放操作导致的模糊问题。

Log: 修复了缩放操作导致的图标模糊问题

Influence:
1. 测试不同缩放级别下的图标渲染效果
2. 验证缩放后主题图标的清晰度
3. 检查非主题图标缩放后的清晰度
4. 测试不同DPI设置下的图标显示效果

PMS: BUG-321383

## Summary by Sourcery

Bug Fixes:
- Prevent icon blurring by moving updateDevicePixelRatio calls outside the ThemeIconName condition in both initialization and pixmapChange methods