### PR TITLE
fix: add missing right bracket

### DIFF
--- a/src/dapploader.cpp
+++ b/src/dapploader.cpp
@@ -441,7 +441,7 @@ void DAppLoaderPrivate::_q_onComponentProgressChanged()
     qreal progress = 0;
     auto components = appRootItem->findChildren<QQmlComponent *>();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    for (auto childCom : std::as_const(components) {
+    for (auto childCom : std::as_const(components)) {
 #else
     for (auto childCom : qAsConst(components)) {
 #endif


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing right parenthesis in the std::as_const iteration for QQmlComponent under QT6 branch