### PR TITLE
fix: improve ComboBox layout and popup behavior

### DIFF
--- a/qt6/src/qml/ArrowListView.qml
+++ b/qt6/src/qml/ArrowListView.qml
@@ -62,6 +62,18 @@ FocusScope {
             highlightFollowsCurrentItem: true
             highlightMoveDuration: -1
             highlightMoveVelocity: 400
+
+            onCountChanged: refreshContentItemWidth()
+            onWidthChanged: refreshContentItemWidth()
+
+            function refreshContentItemWidth() {
+                for (var i = 0; i < itemsView.count; ++i) {
+                    var item = itemsView.itemAtIndex(i)
+                    if (item) {
+                        item.width = itemsView.width
+                    }
+                }
+            }
         }
 
         P.ArrowListViewButton {

--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -30,7 +30,7 @@ T.ComboBox {
     rightPadding: padding + (control.mirrored || !indicator || !indicator.visible ? 0 : indicator.width + spacing)
 
     delegate: MenuItem {
-        implicitWidth: ListView.view.width
+        implicitWidth: Math.max(DS.Style.control.implicitWidth(control), popup.implicitWidth - DS.Style.popup.margin * 2)
         useIndicatorPadding: true
         text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : (model[control.textRole] === undefined ? modelData[control.textRole] : model[control.textRole])) : modelData
         icon.name: (control.iconNameRole && model[control.iconNameRole] !== undefined) ? model[control.iconNameRole] : null
@@ -103,9 +103,12 @@ T.ComboBox {
         }
 
         T.TextField {
-            Layout.fillWidth: true
+            Layout.fillWidth: !control.flat
             Layout.fillHeight: true
+            implicitWidth: control.flat ? contentWidth : implicitBackgroundWidth + leftInset + rightInset
+                   || contentWidth + leftPadding + rightPadding
             Layout.rightMargin: DS.Style.comboBox.spacing
+            Layout.alignment: control.flat ? Qt.AlignVCenter | Qt.AlignRight : Qt.AlignVCenter | Qt.AlignLeft
             text: control.editable ? control.editText : control.displayText
 
             enabled: control.editable
@@ -124,7 +127,8 @@ T.ComboBox {
     }
 
     background: Item {
-        implicitWidth: DS.Style.comboBox.width
+        implicitWidth: control.flat ? control.implicitContentWidth + control.leftPadding + control.rightPadding
+                        : DS.Style.comboBox.width
         implicitHeight: DS.Style.comboBox.height
         Loader {
             anchors.fill: parent
@@ -156,8 +160,11 @@ T.ComboBox {
     }
 
     popup: Popup {
+        id: popup
+        leftMargin: DS.Style.popup.margin
+        rightMargin: DS.Style.popup.margin
         palette: control.palette
-        implicitWidth: control.width
+        implicitWidth: control.flat ? Math.max(contentItem.implicitWidth, control.width) : control.width
         contentItem: ArrowListView {
             clip: true
             maxVisibleItems: control.maxVisibleItems

--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -565,6 +565,7 @@ QtObject {
         property int height: 180
         property int radius: 18
         property int padding: 10
+        property int margin: 10
     }
 
     property QtObject floatingMessage: QtObject {


### PR DESCRIPTION
1. Removed implicitWidth from delegate to prevent fixed width issues
2. Adjusted TextField layout to handle flat mode properly with dynamic width calculation
3. Modified background implicitWidth to support both flat and regular modes
4. Enhanced popup with margins and dynamic width adjustment for flat mode
5. Added arrowListView refresh mechanism to ensure proper item width synchronization

fix: 改进组合框布局和弹出行为

1. 从委托中移除隐式宽度以防止固定宽度问题
2. 调整文本框布局以正确处理扁平模式下的动态宽度计算
3. 修改背景隐式宽度以支持扁平和常规两种模式
4. 增强弹出窗口，添加边距并为扁平模式提供动态宽度调整
5. 添加箭头列表视图刷新机制以确保正确的项目宽度同步

pms: BUG-310431
pms: BUG-310427

## Summary by Sourcery

Improve ComboBox layout and popup behavior by enabling dynamic width adjustments in flat mode, adding margins, and syncing popup item widths.

Bug Fixes:
- Remove implicit width in delegate to prevent fixed width issues
- Correct implicitWidth calculation in TextField and background to support both flat and regular modes

Enhancements:
- Add left and right margins to the popup and adjust its width dynamically in flat mode
- Implement an arrowListView refresh mechanism to synchronize item widths on resize and item count changes