### PR TITLE
fix: adjust scrollbar visibility conditions

### DIFF
--- a/qt6/src/qml/ScrollBar.qml
+++ b/qt6/src/qml/ScrollBar.qml
@@ -31,7 +31,7 @@ T.ScrollBar {
         State {
             name: "normal"
             property bool moving: control.active && !control.pressed && !control.hovered
-            when: control.policy === T.ScrollBar.AlwaysOn || ( moving && control.size < 1.0)
+            when: (control.policy === T.ScrollBar.AlwaysOn && !control.hovered && !control.pressed) || (moving && control.size < 1.0)
             PropertyChanges {
                 target: control.contentItem
                 implicitWidth: DS.Style.scrollBar.width
@@ -39,7 +39,7 @@ T.ScrollBar {
         },
         State {
             name: "hover"
-            when: control.policy === T.ScrollBar.AlwaysOn || ( control.hovered && !control.pressed && control.size < 1.0)
+            when: (control.hovered && !control.pressed && control.size < 1.0)
             PropertyChanges {
                 target: control.contentItem
                 implicitWidth: DS.Style.scrollBar.activeWidth
@@ -47,7 +47,7 @@ T.ScrollBar {
         },
         State {
             name: "active"
-            when: control.policy === T.ScrollBar.AlwaysOn || (control.pressed && control.size < 1.0)
+            when: (control.pressed && control.size < 1.0)
             PropertyChanges {
                 target: control.contentItem
                 implicitWidth: DS.Style.scrollBar.activeWidth


### PR DESCRIPTION
Fixed scrollbar visibility logic to properly handle AlwaysOn policy with hover/pressed states. The original condition would show scrollbar in AlwaysOn mode even when hovered or pressed, which caused visual inconsistency. Now the scrollbar only shows in AlwaysOn mode when not hovered and not pressed, maintaining consistent behavior with other states.

fix: 调整滚动条可见性条件

修复滚动条可见性逻辑以正确处理 AlwaysOn 策略与悬停/按下状态。原始条件会
在 AlwaysOn 模式下即使悬停或按下时也显示滚动条，这导致视觉不一致。现在
滚动条仅在未悬停且未按下时的 AlwaysOn 模式下显示，保持与其他状态一致的
行为。

Pms: BUG-332031

## Summary by Sourcery

Bug Fixes:
- Prevent scrollbar from showing in AlwaysOn mode when hovered or pressed