### PR TITLE
fix: hide arrow buttons at list boundaries

### DIFF
--- a/qt6/src/qml/ArrowListView.qml
+++ b/qt6/src/qml/ArrowListView.qml
@@ -22,7 +22,7 @@ FocusScope {
         id: contentLayout
         anchors.fill: parent
         P.ArrowListViewButton {
-            visible: itemsView.interactive
+            visible: itemsView.interactive && !itemsView.atYBeginning
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.preferredHeight: height
@@ -77,7 +77,7 @@ FocusScope {
         }
 
         P.ArrowListViewButton {
-            visible: itemsView.interactive
+            visible: itemsView.interactive && !itemsView.atYEnd
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.preferredHeight: height


### PR DESCRIPTION
Fixed arrow button visibility logic in ArrowListView to properly hide
buttons when reaching the beginning or end of the list. Previously,
arrow buttons were only hidden when the list was non-interactive, but
remained visible even when at the boundaries of scrollable content.

The changes add boundary checks to the visibility conditions:
- Up arrow button now hides when at the beginning of the list
(atYBeginning)
- Down arrow button now hides when at the end of the list (atYEnd)

This provides better visual feedback to users and prevents unnecessary
button display when no further scrolling is possible.

Log: Fixed arrow button visibility in lists to hide when reaching
boundaries

Influence:
1. Test scrolling through lists with varying content lengths
2. Verify up arrow hides when reaching the top of the list
3. Verify down arrow hides when reaching the bottom of the list
4. Test with both interactive and non-interactive lists
5. Verify button visibility during scroll animations
6. Test edge cases with very short lists

fix: 修复列表边界箭头按钮显示问题

修复了ArrowListView中箭头按钮的可见性逻辑，使其在到达列表边界时正确隐藏
按钮。之前箭头按钮仅在列表不可交互时隐藏，但在可滚动内容边界处仍然显示。

修改为可见性条件添加了边界检查：
- 向上箭头按钮在到达列表开头时隐藏（atYBeginning）
- 向下箭头按钮在到达列表末尾时隐藏（atYEnd）

这为用户提供了更好的视觉反馈，并在无法进一步滚动时避免不必要的按钮显示。

Log: 修复列表边界处箭头按钮的显示问题

Influence:
1. 测试不同长度列表的滚动功能
2. 验证到达列表顶部时向上箭头是否隐藏
3. 验证到达列表底部时向下箭头是否隐藏
4. 测试交互式和非交互式列表的情况
5. 验证滚动动画期间的按钮可见性
6. 测试极短列表的边缘情况

PMS: BUG-278697
