### PR TITLE
fix: fix AlertToolTip background styling

### DIFF
--- a/qt6/src/qml/AlertToolTip.qml
+++ b/qt6/src/qml/AlertToolTip.qml
@@ -21,6 +21,9 @@ ToolTip {
     closePolicy: Popup.NoAutoClose
 
     background: FloatingPanel {
+        radius: DS.Style.alertToolTip.radius
+        implicitWidth: DS.Style.alertToolTip.width
+        implicitHeight: DS.Style.alertToolTip.height
         backgroundColor: DS.Style.alertToolTip.background
         insideBorderColor: DS.Style.alertToolTip.insideBorder
         outsideBorderColor: DS.Style.alertToolTip.outsideBorder

--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -615,6 +615,9 @@ QtObject {
         property int connectorHeight: 12
         property int verticalPadding: 4
         property int horizontalPadding: 10
+        property int width: 30
+        property int height: 24
+        property int radius: 6
 
         property D.Palette text: D.Palette {
             normal: ("#e15736")


### PR DESCRIPTION
Added missing style properties to AlertToolTip background component
to ensure proper visual appearance. The radius, implicitWidth,
and implicitHeight properties were missing from the FloatingPanel
background, causing inconsistent styling with the design system.
Also added corresponding width, height, and radius properties to
the alertToolTip style definition to provide proper values for these
properties.

The changes ensure that AlertToolTip maintains consistent styling with
the design system specifications and displays correctly with proper
dimensions and rounded corners.

Log: Fixed AlertToolTip background styling to match design
specifications

Influence:
1. Verify AlertToolTip displays with correct rounded corners
2. Test that tooltip has proper width and height dimensions
3. Check that background styling is consistent with other components
4. Verify tooltip positioning and layout with new size properties
5. Test on different screen sizes to ensure responsive behavior

fix: 修复AlertToolTip背景样式问题

为AlertToolTip背景组件添加缺失的样式属性以确保正确的视觉外观。
FloatingPanel背景中缺少radius、implicitWidth和implicitHeight属性，导致
与设计系统的样式不一致。同时为alertToolTip样式定义添加了相应的width、
height和radius属性，为这些属性提供正确的值。

这些更改确保AlertToolTip保持与设计系统规范一致的样式，并以正确的尺寸和圆
角显示。

Log: 修复AlertToolTip背景样式以符合设计规范

Influence:
1. 验证AlertToolTip是否以正确的圆角显示
2. 测试工具提示是否具有正确的宽度和高度尺寸
3. 检查背景样式是否与其他组件保持一致
4. 使用新的尺寸属性验证工具提示的定位和布局
5. 在不同屏幕尺寸上测试以确保响应式行为

PMS: BUG-334879

## Summary by Sourcery

Add missing styling properties to AlertToolTip background and style definitions to ensure consistent dimensions and rounded corners with the design system.

Bug Fixes:
- Include radius, implicitWidth, and implicitHeight on AlertToolTip's FloatingPanel background.
- Define width, height, and radius properties for alertToolTip in FlowStyle.qml.