### PR TITLE
fix: adjust search box placeholder text color

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -449,8 +449,8 @@ QtObject {
         }
 
         property D.Palette placeholderText: D.Palette {
-            normal: Qt.rgba(0.33, 0.33, 0.33, 0.4)
-            normalDark: Qt.rgba(1, 1, 1, 0.3)
+            normal: Qt.rgba(0, 0, 0, 0.7)
+            normalDark: Qt.rgba(1, 1, 1, 0.7)
         }
     }
 

--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -48,6 +48,7 @@ Item {
 
     property D.Palette textColor: DS.Style.button.text
     palette.windowText: D.ColorSelector.textColor
+    objectName: "ColorSelectorMaster"
 
     HoverHandler {
         id: hoverHandler

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -356,7 +356,7 @@ void DQuickControlColorSelector::findAndSetControlParent()
     bool needUpdateControl = true;
     bool needUpdateColorFamily = !m_state->familyIsUserSet;
     do {
-        if (needUpdateControl && _d_isControlItem(parentItem)) {
+        if (needUpdateControl && (_d_isControlItem(parentItem) || specialObjectNameItems().contains(parentItem->objectName()))) {
             needUpdateControl = false;
             setControl(parentItem);
         }
@@ -467,8 +467,12 @@ void DQuickControlColorSelector::setControl(QQuickItem *newControl)
         auto palette = m_control->property("palette").value<QQuickPalette*>();
         connect(palette, &QQuickPalette::changed, this, &DQuickControlColorSelector::updateControlTheme);
 #endif
-        connect(m_control, SIGNAL(paletteChanged()), this, SLOT(updateControlTheme()));
-        connect(m_control, SIGNAL(hoveredChanged()), this, SLOT(updateControlState()));
+        if (m_control->metaObject()->indexOfSignal("paletteChanged()") != -1) {
+            connect(m_control, SIGNAL(paletteChanged()), this, SLOT(updateControlTheme()));
+        }
+        if (m_control->metaObject()->indexOfSignal("hoveredChanged()") != -1) {
+            connect(m_control, SIGNAL(hoveredChanged()), this, SLOT(updateControlState()));
+        }
         if (m_control->metaObject()->indexOfSignal("pressedChanged()") != -1) {
             connect(m_control, SIGNAL(pressedChanged()), this, SLOT(updateControlState()));
         }


### PR DESCRIPTION
Updated placeholder text color palette in FlowStyle.qml to improve
visibility and contrast. Changed normal mode from semi-transparent dark
gray to more opaque black, and dark mode from semi-transparent white to
more opaque white. This addresses the search box text color issue where
placeholder text was not clearly visible.

Added objectName property to TitleBar.qml to support special handling in
color selector logic. Modified DQuickControlColorSelector to check for
special object names when finding control parent, ensuring proper color
inheritance for components with specific object names.

Enhanced signal connection safety in DQuickControlColorSelector
by checking if signals exist before connecting to them, preventing
potential runtime errors when signals are not available on certain
control items.

Log: Improved search box placeholder text visibility

Influence:
1. Test search box placeholder text visibility in both light and dark
themes
2. Verify color consistency across different UI components
3. Test color inheritance for components with special object names
4. Verify no runtime errors occur during palette updates
5. Check hover and press state changes work correctly

fix: 调整搜索框占位符文字颜色

更新了 FlowStyle.qml 中的占位符文字颜色调色板以提高可见性和对比度。将普
通模式从半透明深灰色改为更不透明的黑色，暗黑模式从半透明白色改为更不透明
的白色。这解决了搜索框文字颜色问题，之前占位符文字不够清晰可见。

在 TitleBar.qml 中添加了 objectName 属性以支持颜色选择器逻辑中的特殊处
理。修改了 DQuickControlColorSelector 在查找控件父级时检查特殊对象名称，
确保具有特定对象名称的组件能够正确继承颜色。

增强了 DQuickControlColorSelector 中的信号连接安全性，在连接信号前检查信
号是否存在，防止在某些控件项上信号不可用时出现运行时错误。

Log: 改进了搜索框占位符文字的可见性

Influence:
1. 测试浅色和深色主题下搜索框占位符文字的可见性
2. 验证不同UI组件间的颜色一致性
3. 测试具有特殊对象名称的组件的颜色继承
4. 验证调色板更新时不会出现运行时错误
5. 检查悬停和按下状态变化是否正常工作

PMS: BUG-271269

## Summary by Sourcery

Improve placeholder text contrast and reinforce color selector logic by handling special object names and ensuring safe signal connections

Bug Fixes:
- Update FlowStyle.qml to use more opaque placeholder text colors in both light and dark modes for better visibility

Enhancements:
- Add objectName "ColorSelectorMaster" to TitleBar.qml and extend DQuickControlColorSelector to recognize special object names for proper color inheritance
- Guard connections to paletteChanged and hoveredChanged signals in DQuickControlColorSelector by checking their existence to prevent runtime errors