### PR TITLE
fix: handle inactive state colors in DQuickControlPalette

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -842,6 +842,17 @@ QColor DQuickControlColorSelector::getColorOf(const DQuickControlPalette *palett
         colorValue = QColor(255 - r, 255 - g, 255 - b, a);
     }
 
+    // items with inactive state should use inactive color, it likes dtkgui's generatePaletteColor_helper.
+    static const auto useInactiveColor = DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::UseInactiveColorGroup);
+    if (useInactiveColor && state->controlState == DQMLGlobalObject::InactiveState) {
+        const auto &palette = DGuiApplicationHelper::standardPalette(state->controlTheme);
+        const auto &windowColor = palette.color(QPalette::Window);
+
+        QColor inactiveMaskColor = windowColor;
+        inactiveMaskColor.setAlphaF(state->controlTheme == DGuiApplicationHelper::DarkType ? 0.6 : 0.4);
+        colorValue = DGuiApplicationHelper::blendColor(colorValue, inactiveMaskColor);
+    }
+
     return colorValue;
 }
 


### PR DESCRIPTION
Added support for inactive state color handling in
DQuickControlColorSelector::getColorOf method. When the control state
is inactive and the system attribute UseInactiveColorGroup is enabled,
the function now applies an inactive color mask similar to dtkgui's
generatePaletteColor_helper implementation. The inactive color is
generated by blending the original color with a window color-based mask
that has different alpha values for dark (0.6) and light (0.4) themes,
ensuring proper visual appearance for inactive controls.

Log: Fixed inactive state color handling in DQuickControlPalette

Influence:
1. Test UI controls in inactive state with both dark and light themes
2. Verify inactive controls display properly dimmed colors
3. Check that active controls remain unaffected by the inactive color
processing
4. Test with UseInactiveColorGroup attribute enabled and disabled
5. Verify color consistency across different control types and states

fix: 在DQuickControlPalette中处理非活动状态颜色

在DQuickControlColorSelector::getColorOf方法中添加了对非活动状态颜色处理
的支持。当控件状态为非活动状态且系统属性UseInactiveColorGroup启用时，该
函数现在会应用类似于dtkgui的generatePaletteColor_helper实现的非活动颜色
遮罩。通过将原始颜色与基于窗口颜色的遮罩进行混合来生成非活动颜色，该遮罩
针对深色（0.6）和浅色（0.4）主题具有不同的alpha值，确保非活动控件的正确
视觉外观。

Log: 修复了DQuickControlPalette中非活动状态颜色处理问题

Influence:
1. 测试深色和浅色主题下的非活动状态UI控件
2. 验证非活动控件正确显示变暗的颜色
3. 检查活动控件不受非活动颜色处理的影响
4. 测试启用和禁用UseInactiveColorGroup属性时的情况
5. 验证不同控件类型和状态下的颜色一致性

PMS: BUG-298569
