### PR TITLE
fix: adjust AlertToolTip position and animations

### DIFF
--- a/qt6/src/qml/AlertToolTip.qml
+++ b/qt6/src/qml/AlertToolTip.qml
@@ -11,6 +11,7 @@ ToolTip {
     property Item target
 
     x: 0
+    y: target ? target.height + DS.Style.control.spacing : 0
     topPadding: DS.Style.alertToolTip.verticalPadding
     bottomPadding: DS.Style.alertToolTip.verticalPadding
     leftPadding: DS.Style.alertToolTip.horizontalPadding
@@ -40,12 +41,13 @@ ToolTip {
     }
 
     enter: Transition {
-        NumberAnimation { properties: "opacity"; from: 0.0; to: 1.0; duration: 200 }
+        // TODO: Transparency causes tooltips to appear through the window background - temporarily removed
+        // NumberAnimation { properties: "opacity"; from: 0.0; to: 1.0; duration: 200 }
         NumberAnimation { properties: "y"; from: control.target.height; to: control.target.height + DS.Style.control.spacing; duration: 200 }
     }
 
     exit: Transition {
-        NumberAnimation { properties: "opacity"; from: 1.0; to: 0.0 }
+        // NumberAnimation { properties: "opacity"; from: 1.0; to: 0.0 }
         NumberAnimation { properties: "y"; from: control.target.height + DS.Style.control.spacing ; to: control.target.height }
     }
 }


### PR DESCRIPTION
1. Added y-position calculation to position tooltip below target element with proper spacing
2. Removed opacity animations temporarily due to transparency causing tooltips to appear through window background
3. Maintained vertical slide animations for enter/exit transitions
4. The opacity animations are commented with TODO for future fix when transparency issue is resolved

fix: 调整 AlertToolTip 位置和动画效果

1. 添加 y 位置计算，使工具提示在目标元素下方以适当间距定位
2. 暂时移除透明度动画，因为透明度会导致工具提示透过窗口背景显示
3. 保留垂直滑动动画用于进入/退出过渡
4. 透明度动画已添加 TODO 注释，待透明度问题解决后修复

pms: BUG-334771

## Summary by Sourcery

Adjust the AlertToolTip component to position below its target with correct spacing, temporarily remove opacity transitions to avoid transparency issues, and retain vertical slide animations for enter/exit transitions.

Enhancements:
- Calculate the y-position of AlertToolTip to position it below the target element with DS.Style.control.spacing
- Comment out opacity animations due to transparency causing tooltips to render through the window background
- Maintain vertical slide NumberAnimation for enter and exit transitions