### PR TITLE
feat: add license dialog and update about dialog

### DIFF
--- a/qmlplugin/qmlplugin_plugin.cpp
+++ b/qmlplugin/qmlplugin_plugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -28,6 +28,7 @@
 #include "private/dquickarrowboxpath_p.h"
 #include "private/dquickcoloroverlay_p.h"
 #include "private/dquickapploaderitem_p.h"
+#include "private/dlicenseinfoprovider_p.h"
 #endif
 
 #include "private/dquickimageprovider_p.h"
@@ -195,6 +196,7 @@ void QmlpluginPlugin::registerTypes(const char *uri)
     dtkRegisterType<DQuickArrowBoxPath>(uri, implUri, 1, 0, "ArrowBoxPath");
     dtkRegisterType<DQuickAppLoaderItem>(uri, implUri, 1, 0, "AppLoader");
     dtkRegisterType<DQuickColorOverlay>(uri, implUri, 1, 0, "SoftwareColorOverlay");
+    dtkRegisterType<DLicenseInfoProvider>(uri, implUri, 1, 0, "LicenseInfoProvider");
 
     dtkRegisterAnonymousType<DQUICK_NAMESPACE::DQuickDciIcon>(uri, implUri, 1);
     dtkRegisterAnonymousType<DQuickControlColor>(uri, implUri, 1);

--- a/qt6/src/qml.cmake
+++ b/qt6/src/qml.cmake
@@ -100,6 +100,7 @@ set(QML_DTK_CONTROLS
     "qml/ControlGroup.qml"
     "qml/ControlGroupItem.qml"
     "qml/DragItemsImage.qml"
+    "qml/LicenseDialog.qml"
 )
 
 foreach(QML_FILE ${QML_DTK_CONTROLS})

--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -18,8 +18,9 @@ DialogWindow {
     property alias productIcon: logoLabel.icon.name
     property alias version: versionLabel.text
     property alias description: descriptionLabel.text
-    property alias license: licenseLabel.text
     property alias companyLogo: companyLogoLabel.source
+    property alias license: licenseLabel.text
+    property string licensePath
     property string websiteName
     property string websiteLink
 
@@ -59,6 +60,7 @@ DialogWindow {
                 Layout.alignment: Qt.AlignCenter
                 Layout.topMargin: 30
             }
+
             Label {
                 id: licenseLabel
                 font: D.DTK.fontManager.t10
@@ -68,7 +70,7 @@ DialogWindow {
                 Layout.leftMargin: 30
                 wrapMode: Text.WordWrap
                 elide: Text.ElideRight
-                visible: license !== ""
+                visible: control.license !== ""
             }
         }
         ColumnLayout {
@@ -127,6 +129,31 @@ DialogWindow {
                     elide: Text.ElideRight
                 }
             }
+
+            ColumnLayout {
+                spacing: 1
+                Label {
+                    font: D.DTK.fontManager.t10
+                    text: qsTr("Acknowledgements")
+                }
+                Label {
+                    id: acknowledgmentsLabel
+                    text: qsTr("Sincerely appreciate the %1 used.").arg(control.__websiteLinkTemplate.arg("-").arg(qsTr("open-source software")))
+                    textFormat: Text.RichText
+                    Layout.fillWidth: true
+                    font: D.DTK.fontManager.t8
+                    wrapMode: Text.WordWrap
+                    elide: Text.ElideRight
+
+                    onLinkActivated: function(link) {
+                        licenseDialogLoader.active = true
+                    }
+
+                    HoverHandler {
+                        cursorShape: acknowledgmentsLabel.hoveredLink !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    }
+                }
+            }
        }
 
         Component.onCompleted: {
@@ -139,6 +166,20 @@ DialogWindow {
         Keys.onEscapePressed: {
             control.close()
             event.accepted = true
+        }
+    }
+
+    Loader {
+        id: licenseDialogLoader
+        active: false
+        sourceComponent: LicenseDialog {
+            licensePath: control.licensePath
+            onClosing: function (close) {
+                licenseDialogLoader.active = false
+            }
+        }
+        onLoaded: function () {
+            licenseDialogLoader.item.show()
         }
     }
 }

--- a/qt6/src/qml/DialogTitleBar.qml
+++ b/qt6/src/qml/DialogTitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -15,6 +15,7 @@ Item {
     height: DS.Style.dialogWindow.titleBarHeight
 
     // custom control
+    property alias leftContent: customLeft.sourceComponent
     property alias content: customCenter.sourceComponent
     // dialog icon
     property alias icon: iconLabel
@@ -54,7 +55,7 @@ Item {
         }
 
         RowLayout {
-            spacing: 0
+            spacing: 10
             Layout.alignment: Qt.AlignHCenter
             Layout.fillHeight: true
             Layout.preferredWidth: parent.width
@@ -75,10 +76,17 @@ Item {
                 }
             }
 
+            // left custom area
+            Loader {
+                id: customLeft
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillHeight: true
+                sourceComponent: null
+            }
+
             // center custom area
             Loader {
                 id: customCenter
-                Layout.leftMargin: closeBtn.width - iconLabel.width
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 Layout.fillWidth: true

--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -47,6 +47,7 @@ Window {
                 sourceComponent: DialogTitleBar {
                     enableInWindowBlendBlur: true
                     icon.name: control.icon
+                    title: control.title
                 }
             }
 

--- a/qt6/src/qml/LicenseDialog.qml
+++ b/qt6/src/qml/LicenseDialog.qml
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Window
+import QtQuick.Controls
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
+
+DialogWindow {
+    id: control
+    width: 800
+    height: 900
+    title: qsTr("open-source software")
+
+    property alias licensePath: licenseProvider.path
+
+    header: D.DialogTitleBar {
+        title: control.title
+        leftContent: Item {
+            width: 32
+            D.IconButton {
+                anchors.centerIn: parent
+                visible: stackView.depth > 1
+                icon.name: "arrow_ordinary_left"
+                implicitWidth: 32
+                implicitHeight: 32
+                icon.width: 12
+                icon.height: 12
+                onClicked: stackView.pop()
+            }
+        }  
+    }
+
+    Item {
+        implicitWidth: control.width - control.leftPadding - control.rightPadding
+        implicitHeight: control.height - DS.Style.dialogWindow.titleBarHeight - DS.Style.dialogWindow.contentHMargin
+
+        D.LicenseInfoProvider {
+            id: licenseProvider
+        }
+
+        StackView {
+            id: stackView
+            anchors.fill: parent
+            initialItem: listPage
+            clip: true
+        }
+
+        Component {
+            id: listPage
+            Item {
+                ListView {
+                    id: licenseList
+                    anchors.fill: parent
+                    clip: true
+                    model: licenseProvider.licenseList
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: D.ItemDelegate {
+                        id: delegateItem
+                        implicitWidth: licenseList.width
+                        implicitHeight: 50
+                        text: modelData.name
+                        palette.windowText: undefined
+                        property D.Palette colorOdd: D.Palette {
+                            normal: Qt.rgba(0, 0, 0, 0.05)
+                            hovered: Qt.rgba(0, 0, 0, 0.1)
+                        }
+                        property D.Palette colorEven: D.Palette {
+                            normal: Qt.rgba(0, 0, 0, 0.02)
+                            hovered: Qt.rgba(0, 0, 0, 0.1)
+                        }
+
+                        onClicked: {
+                            stackView.push(detailPage, {
+                                packageName: modelData.name,
+                                licenseText: licenseProvider.licenseContent(modelData.licenseName)
+                            })
+                        }
+                        background: D.BoxPanel {
+                            color1: index % 2 === 0 ? delegateItem.colorOdd : delegateItem.colorEven
+                            insideBorderColor: null
+                            outsideBorderColor: null
+                            dropShadowColor: null
+                            innerShadowColor1: null
+                            innerShadowColor2: null
+                        }
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: detailPage
+            Item {
+                property string packageName: ""
+                property string licenseText: ""
+
+                Flickable {
+                    anchors.fill: parent
+                    contentWidth: width
+                    contentHeight: detailColumn.implicitHeight
+                    clip: true
+                    topMargin: 20
+                    ScrollBar.vertical: ScrollBar {}
+
+                    ColumnLayout {
+                        id: detailColumn
+                        width: parent.width
+                        spacing: 20
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: packageName
+                            font.pixelSize: D.DTK.fontManager.t5.pixelSize
+                            font.family: D.DTK.fontManager.t5.family
+                            font.bold: true
+                            color: D.DTK.palette.windowText
+                        }
+
+                        MenuSeparator{}
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: licenseText
+                            font: D.DTK.fontManager.t6
+                            color: D.DTK.palette.windowText
+                            wrapMode: Text.WordWrap
+                            verticalAlignment: Text.AlignTop
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/private/dlicenseinfoprovider.cpp
+++ b/src/private/dlicenseinfoprovider.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dlicenseinfoprovider_p.h"
+
+DQUICK_BEGIN_NAMESPACE
+
+DLicenseInfoProvider::DLicenseInfoProvider(QObject *parent)
+    : QObject(parent)
+{
+}
+
+DLicenseInfoProvider::~DLicenseInfoProvider() = default;
+
+QVariantList DLicenseInfoProvider::licenseList() const
+{
+    auto componentInfos = m_licenseInfo.componentInfos();
+    QVariantList list;
+    for (const auto &info : componentInfos) {
+        QVariantMap map;
+        map.insert("name", info->name());
+        map.insert("version", info->version());
+        map.insert("copyRight", info->copyRight());
+        map.insert("licenseName", info->licenseName());
+        list.append(map);
+    }
+    return list;
+}
+
+QString DLicenseInfoProvider::path() const
+{
+    return m_path;
+}
+
+void DLicenseInfoProvider::setPath(const QString &path)
+{
+    if (m_path == path)
+        return;
+    m_path = path;
+    Q_EMIT pathChanged();
+    setValid(m_licenseInfo.loadFile(path));
+    Q_EMIT licenseListChanged();
+}
+
+bool DLicenseInfoProvider::isValid() const
+{
+    return m_valid;
+}
+
+void DLicenseInfoProvider::setValid(bool valid)
+{
+    if (m_valid == valid)
+        return;
+    m_valid = valid;
+    Q_EMIT validChanged();
+}
+
+QString DLicenseInfoProvider::licenseContent(const QString &licenseName)
+{
+    return QString::fromUtf8(m_licenseInfo.licenseContent(licenseName));
+}
+
+void DLicenseInfoProvider::componentComplete()
+{
+    setValid(m_licenseInfo.loadFile({}));
+    Q_EMIT licenseListChanged();
+}
+
+DQUICK_END_NAMESPACE

--- a/src/private/dlicenseinfoprovider_p.h
+++ b/src/private/dlicenseinfoprovider_p.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <dtkcore_global.h>
+#include <dtkdeclarative_global.h>
+
+#include <QQmlParserStatus>
+#include <QtQml/qqml.h>
+
+#include <DLicenseInfo>
+
+DQUICK_BEGIN_NAMESPACE
+DCORE_USE_NAMESPACE
+
+class DLicenseInfoProvider : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QML_NAMED_ELEMENT(LicenseInfoProvider)
+#endif
+
+    Q_PROPERTY(QVariantList licenseList READ licenseList NOTIFY licenseListChanged)
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+    Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
+
+public:
+    explicit DLicenseInfoProvider(QObject *parent = nullptr);
+    ~DLicenseInfoProvider() override;
+
+    QVariantList licenseList() const;
+
+    // path to a custom license JSON file
+    QString path() const;
+    void setPath(const QString &path);
+
+    bool isValid() const;
+    void setValid(bool valid);
+
+    Q_INVOKABLE QString licenseContent(const QString &licenseName);
+
+Q_SIGNALS:
+    void pathChanged();
+    void validChanged();
+    void licenseListChanged();
+
+private:
+    void classBegin() override {};
+    void componentComplete() override;
+
+private:
+    DLicenseInfo m_licenseInfo;
+    QVariantList m_componentInfoList;
+    QString m_path;
+    bool m_valid = false;
+};
+
+DQUICK_END_NAMESPACE

--- a/src/translations/dtkdeclarative.ts
+++ b/src/translations/dtkdeclarative.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,48 +69,40 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SettingsDialog</name>
-    <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
-        <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
@@ -95,22 +110,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/dtkdeclarative_am_ET.ts
+++ b/src/translations/dtkdeclarative_am_ET.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="am_ET">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="am_ET">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>ስለ</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>እርዳታ</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>መውጫ</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>ነባር እንደ ነበር መመለሻ</translation>
+        <translation type="vanished">ነባር እንደ ነበር መመለሻ</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_ar.ts
+++ b/src/translations/dtkdeclarative_ar.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>حول</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>الصفحة الرئيسية</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>مساعدة</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>خروج</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>بحث</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>استعادة الإعدادت الإفتراضية</translation>
+        <translation type="vanished">استعادة الإعدادت الإفتراضية</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>تحديد الكل</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>الموضوع</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>سمة فاتحة</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>سمة غامقة</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>سمة النظام</translation>
     </message>

--- a/src/translations/dtkdeclarative_az.ts
+++ b/src/translations/dtkdeclarative_az.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Haqqında</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Ev səhifəsi</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Təsviri</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Çıxış</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Axtarış</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Standartları bərpa edin</translation>
+        <translation type="vanished">Standartları bərpa edin</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Hamısını seçin</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Mövzu</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>İşıqlı mövzu</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tutqun mövzu</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Sistem mövzusu</translation>
     </message>

--- a/src/translations/dtkdeclarative_bg.ts
+++ b/src/translations/dtkdeclarative_bg.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bg">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Относно</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Помощ</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Изход</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Възстановяване на настройките</translation>
+        <translation type="vanished">Възстановяване на настройките</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_bn.ts
+++ b/src/translations/dtkdeclarative_bn.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>সম্পর্কে</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>সাহায্য</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>বের হয়ে যান</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>পূর্বনির্ধারিত জিনিসে ফিরে যান</translation>
+        <translation type="vanished">পূর্বনির্ধারিত জিনিসে ফিরে যান</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_bo.ts
+++ b/src/translations/dtkdeclarative_bo.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>སྐོར།</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>པར་གཞི།  </translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>གཙོ་ངོས།</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>ཞིབ་བརྗོད།</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>རོགས་པ།</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>ཕྱིར་འབུད།</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>འཚོལ་ཞིབ།</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>སོར་བཞག་སླར་གསོ།</translation>
+        <translation type="vanished">སོར་བཞག་སླར་གསོ།</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>བརྗོད་བྱ་གཙོ་བོ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>ཁ་དཀར་པོ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>ཁ་སྨུག་པོ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>མ་ལག་གི་རྗེས་འབྲངས་བ།</translation>
     </message>

--- a/src/translations/dtkdeclarative_br.ts
+++ b/src/translations/dtkdeclarative_br.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="br">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Diwar-benn</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Skoazell</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Kuitaat</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Klask</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Adderaouiñ</translation>
+        <translation type="vanished">Adderaouiñ</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tem</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tem sklaer</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tem teñval</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tem ar sistem</translation>
     </message>

--- a/src/translations/dtkdeclarative_ca.ts
+++ b/src/translations/dtkdeclarative_ca.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Quant a</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Pàgina inicial</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descripció</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Surt</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restableix els valors per defecte</translation>
+        <translation type="vanished">Restableix els valors per defecte</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Retalla</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Enganxa</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Desfés</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Refés</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema clar</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema fosc</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema del sistema</translation>
     </message>

--- a/src/translations/dtkdeclarative_cs.ts
+++ b/src/translations/dtkdeclarative_cs.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>O aplikaci</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Domovská stránka</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Popis</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Ukončit</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Vrátit na výchozí hodnoty</translation>
+        <translation type="vanished">Vrátit na výchozí hodnoty</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Vzhled</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Světlý vzhled</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tmavý vzhled</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Systémový vzhled</translation>
     </message>

--- a/src/translations/dtkdeclarative_da.ts
+++ b/src/translations/dtkdeclarative_da.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="da">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Hjælp</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Afslut</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Søg</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Gendan standarder</translation>
+        <translation type="vanished">Gendan standarder</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Lyst tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Mørkt tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Systemets tema</translation>
     </message>

--- a/src/translations/dtkdeclarative_de.ts
+++ b/src/translations/dtkdeclarative_de.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Homepage</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Beenden</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Standardeinstellungen wiederherstellen</translation>
+        <translation type="vanished">Standardeinstellungen wiederherstellen</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Helles Thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Dunkles Thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Systemthema</translation>
     </message>

--- a/src/translations/dtkdeclarative_el.ts
+++ b/src/translations/dtkdeclarative_el.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="el">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Περί</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Βοήθεια</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Έξοδος</translation>
     </message>
@@ -44,73 +69,65 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>SettingsDialog</name>
-    <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
-        <source>Restore Defaults</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_es.ts
+++ b/src/translations/dtkdeclarative_es.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Página web</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descripción</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restaurar valores predeterminados</translation>
+        <translation type="vanished">Restaurar valores predeterminados</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema claro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema oscuro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema del sistema</translation>
     </message>

--- a/src/translations/dtkdeclarative_eu.ts
+++ b/src/translations/dtkdeclarative_eu.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="eu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eu">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Honi buruz</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Laguntza</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Irten</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Bilatu</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Leheneratu lehenetsiak</translation>
+        <translation type="vanished">Leheneratu lehenetsiak</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Gaia</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Gai argia</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Gai iluna</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Sistemaren gaia</translation>
     </message>

--- a/src/translations/dtkdeclarative_fa.ts
+++ b/src/translations/dtkdeclarative_fa.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fa">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fa">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>درباره</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>راهنما</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>خروج</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>جستجو</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>بازیابی پیش فرض</translation>
+        <translation type="vanished">بازیابی پیش فرض</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>تم روشن</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>تم تیره</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>تم سیستم</translation>
     </message>

--- a/src/translations/dtkdeclarative_fi.ts
+++ b/src/translations/dtkdeclarative_fi.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Tietoja</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Kotisivu</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Apua</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Poistu</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Etsi</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Palauta oletukset</translation>
+        <translation type="vanished">Palauta oletukset</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Leikkaa</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Uudelleen</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Teema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Vaalea</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tumma</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Järjestelmän</translation>
     </message>

--- a/src/translations/dtkdeclarative_fr.ts
+++ b/src/translations/dtkdeclarative_fr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Page d&apos;acceuil</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Description</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Chercher</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Réinitialiser</translation>
+        <translation type="vanished">Réinitialiser</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Thème</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Thème clair</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Thème sombre</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Thème du système</translation>
     </message>

--- a/src/translations/dtkdeclarative_gl_ES.ts
+++ b/src/translations/dtkdeclarative_gl_ES.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Páxina de inicio</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descripción</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Axuda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Saír</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restaurar predefinidos</translation>
+        <translation type="vanished">Restaurar predefinidos</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema claro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema escuro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema do sistema</translation>
     </message>

--- a/src/translations/dtkdeclarative_he.ts
+++ b/src/translations/dtkdeclarative_he.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>על אודות</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>עזרה</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>יציאה</translation>
     </message>
@@ -44,73 +69,65 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>SettingsDialog</name>
-    <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
-        <source>Restore Defaults</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_hi_IN.ts
+++ b/src/translations/dtkdeclarative_hi_IN.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hi_IN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>बारे में</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>मदद</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>बंद करें</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>खोजें</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>मूल स्वरूप पुनः स्थापित करें</translation>
+        <translation type="vanished">मूल स्वरूप पुनः स्थापित करें</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>सारा चयनित</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>थीम</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>हल्की थीम</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>गहरी थीम</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>सिस्टम थीम</translation>
     </message>

--- a/src/translations/dtkdeclarative_hr.ts
+++ b/src/translations/dtkdeclarative_hr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>O programu</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Pomoć</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Izlaz</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Traži</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Obnovi zadano</translation>
+        <translation type="vanished">Obnovi zadano</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Odaberi sve</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Svijetla tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tamna tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema sustava</translation>
     </message>

--- a/src/translations/dtkdeclarative_hu.ts
+++ b/src/translations/dtkdeclarative_hu.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Az alkalmazásról</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Kezdőoldal</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Leírás</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Kilépés</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Alapértelmezések visszaállítása</translation>
+        <translation type="vanished">Alapértelmezések visszaállítása</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Téma</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Világos mód</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Sötét mód</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Rendszer téma</translation>
     </message>

--- a/src/translations/dtkdeclarative_id.ts
+++ b/src/translations/dtkdeclarative_id.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="id">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Tentang</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Keluar</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Pulihkan ke baku</translation>
+        <translation type="vanished">Pulihkan ke baku</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_it.ts
+++ b/src/translations/dtkdeclarative_it.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Info</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Homepage</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descrizione</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Esci</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Ripristina valori predefiniti</translation>
+        <translation type="vanished">Ripristina valori predefiniti</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema chiaro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema scuro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema di Sistema</translation>
     </message>

--- a/src/translations/dtkdeclarative_ja.ts
+++ b/src/translations/dtkdeclarative_ja.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>このアプリケーションについて</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>バージョン</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>ホームページ</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>説明</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>終了</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>検索</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>デフォルトに戻す</translation>
+        <translation type="vanished">デフォルトに戻す</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>すべて選択</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>やり直す</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>テーマ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>ライトテーマ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>ダークテーマ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>システムテーマ</translation>
     </message>

--- a/src/translations/dtkdeclarative_ko.ts
+++ b/src/translations/dtkdeclarative_ko.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>프로그램 정보</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>도움말</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>종료</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>검색</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>기본값 복원</translation>
+        <translation type="vanished">기본값 복원</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>테마</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>밝은 색상 테마</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>어두운 색상 테마</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>시스템 테마</translation>
     </message>

--- a/src/translations/dtkdeclarative_lo.ts
+++ b/src/translations/dtkdeclarative_lo.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>ກ່ຽວກັບ</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>ເວີຊັນ</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>ໜ້າຫຼັກ</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>ຄຳອະທິບາຍ</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>ຊ່ວຍເຫຼືອ</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>ອອກ</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>ຄົ້ນຫາ</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>ຄືນຄ່າເລີ່ມຕົ້ນ</translation>
+        <translation type="vanished">ຄືນຄ່າເລີ່ມຕົ້ນ</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>ຄັດລອກ</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>ຕັດ</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>ວາງ</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>ເລືອກທັງໝົດ</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>ຍົກເລີກ</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>ເຮັດຄືນ</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>ຮູບແບບ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>ຮູບແບບສະຫວ່າງ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>ຮູບແບບມືດ</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>ຮູບແບບລະບົບ</translation>
     </message>

--- a/src/translations/dtkdeclarative_lt.ts
+++ b/src/translations/dtkdeclarative_lt.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Apie</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Žinynas</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Išeiti</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Ieškoti</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Atkurti numatytuosius</translation>
+        <translation type="vanished">Atkurti numatytuosius</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Šviesi tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tamsi tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Sistemos tema</translation>
     </message>

--- a/src/translations/dtkdeclarative_ms.ts
+++ b/src/translations/dtkdeclarative_ms.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Perihal</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Laman Utama</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Keterangan</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Keluar</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Gelintar</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Pulih Lalai</translation>
+        <translation type="vanished">Pulih Lalai</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema Cerah</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema Gelap</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema Sistem</translation>
     </message>

--- a/src/translations/dtkdeclarative_nb.ts
+++ b/src/translations/dtkdeclarative_nb.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nb">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nb">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Avslutt</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Gjenopprett Standard</translation>
+        <translation type="vanished">Gjenopprett Standard</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_ne.ts
+++ b/src/translations/dtkdeclarative_ne.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>बारेमा</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>मद्दत</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>बाहिर निस्कनुहोस्</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>खोज्नुहोस्</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>फेरी पहिलाकै अवस्था मा लैजाऊ</translation>
+        <translation type="vanished">फेरी पहिलाकै अवस्था मा लैजाऊ</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>थेम </translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>लाईट थेम</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>दर्क  थेम</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>सिस्टम थेम</translation>
     </message>

--- a/src/translations/dtkdeclarative_nl.ts
+++ b/src/translations/dtkdeclarative_nl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Over</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Website</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Beschrijving</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Standaardwaarden herstellen</translation>
+        <translation type="vanished">Standaardwaarden herstellen</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>&amp;Kopiëren</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Knippen</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Opnieuw uitvoeren</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Licht thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Donker thema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Systeemthema</translation>
     </message>

--- a/src/translations/dtkdeclarative_pl.ts
+++ b/src/translations/dtkdeclarative_pl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>O programie</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Strona główna</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Opis</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Wyjdź</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Przywróć domyślne</translation>
+        <translation type="vanished">Przywróć domyślne</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Ponów</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Motyw</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Jasny</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Ciemny</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Systemowy</translation>
     </message>

--- a/src/translations/dtkdeclarative_pt.ts
+++ b/src/translations/dtkdeclarative_pt.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Página inicial</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descrição</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restaurar predefinições</translation>
+        <translation type="vanished">Restaurar predefinições</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Tema claro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Tema escuro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Tema do sistema</translation>
     </message>

--- a/src/translations/dtkdeclarative_pt_BR.ts
+++ b/src/translations/dtkdeclarative_pt_BR.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Página web</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Descrição</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restaurar padrões</translation>
+        <translation type="vanished">Restaurar padrões</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Claro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Escuro</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Padrão</translation>
     </message>

--- a/src/translations/dtkdeclarative_ro.ts
+++ b/src/translations/dtkdeclarative_ro.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ro">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Despre</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ajutor</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Ieșire</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Căutare</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Restabilirea sătărilor de bază</translation>
+        <translation type="vanished">Restabilirea sătărilor de bază</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Selectați tot</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Temă</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Temă culoare deschisă</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Temă culoare întunecată</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Temă de sistem</translation>
     </message>

--- a/src/translations/dtkdeclarative_ru.ts
+++ b/src/translations/dtkdeclarative_ru.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Домашняя страница</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Выход</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Восстановить значения По-умолчанию</translation>
+        <translation type="vanished">Восстановить значения По-умолчанию</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Выбрать все</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Повторить</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Светлая Тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Темная Тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Тема Системы</translation>
     </message>

--- a/src/translations/dtkdeclarative_sk.ts
+++ b/src/translations/dtkdeclarative_sk.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>O</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Ukončiť</translation>
     </message>
@@ -44,73 +69,72 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Obnoviť predvolené nastavenia</translation>
+        <translation type="vanished">Obnoviť predvolené nastavenia</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/translations/dtkdeclarative_sl.ts
+++ b/src/translations/dtkdeclarative_sl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>O tem</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Domača stran</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Opis</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Pomoč</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Izhod</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>iskanje</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Obnovi privzeto</translation>
+        <translation type="vanished">Obnovi privzeto</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Izberi vse</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Svetla tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Temna tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Sistemska tema</translation>
     </message>

--- a/src/translations/dtkdeclarative_sq.ts
+++ b/src/translations/dtkdeclarative_sq.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Mbi</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Faqe hyrëse</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Përshkrim</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Dil</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Rikthe Parazgjedhjet</translation>
+        <translation type="vanished">Rikthe Parazgjedhjet</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Prije</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Përzgjidhi Krejt</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Zhbëje</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Ribëje</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Temë</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Temë e Çelët</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Temë e Errët</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Temë Sistemi</translation>
     </message>

--- a/src/translations/dtkdeclarative_sr.ts
+++ b/src/translations/dtkdeclarative_sr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>О програму</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Помоћ</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Изађи</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Претражи</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Врати Подразумевано</translation>
+        <translation type="vanished">Врати Подразумевано</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Изабери све</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Светла тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Тамна тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Системска тема</translation>
     </message>

--- a/src/translations/dtkdeclarative_tr.ts
+++ b/src/translations/dtkdeclarative_tr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Hakkında</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Anasayfa</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Açıklama</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Çıkış</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Varsayılanları Geri Yükle</translation>
+        <translation type="vanished">Varsayılanları Geri Yükle</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Açık Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Koyu Tema</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Sistem Teması</translation>
     </message>

--- a/src/translations/dtkdeclarative_ug.ts
+++ b/src/translations/dtkdeclarative_ug.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>ھەققىدە</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>باش بەت</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>تەسۋىر</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>چېكىنىش</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation> ئىزدەش </translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>ئەسلىدىكى تەڭشەك ھالىتىگە قايتۇرۇش</translation>
+        <translation type="vanished">ئەسلىدىكى تەڭشەك ھالىتىگە قايتۇرۇش</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>ھەممە</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>ئۇسلۇب</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>يورۇق ئۇسلۇب</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>قارا ئۇسلۇب</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>سېستىما ئۇسلۇبى</translation>
     </message>

--- a/src/translations/dtkdeclarative_uk.ts
+++ b/src/translations/dtkdeclarative_uk.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>Про програму</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>Домашня сторінка</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>Опис</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>Вийти</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>Відновити значення за замовчуванням</translation>
+        <translation type="vanished">Відновити значення за замовчуванням</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>Вирізати</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>Вибрати усі</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>Повторити</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>Тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>Світла тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>Темна тема</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>Тема системи</translation>
     </message>

--- a/src/translations/dtkdeclarative_zh_CN.ts
+++ b/src/translations/dtkdeclarative_zh_CN.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>主页</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>描述</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -52,40 +77,39 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>恢复默认</translation>
+        <translation type="vanished">恢复默认</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
@@ -93,22 +117,22 @@
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>主题</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>浅色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>跟随系统</translation>
     </message>

--- a/src/translations/dtkdeclarative_zh_HK.ts
+++ b/src/translations/dtkdeclarative_zh_HK.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>主頁</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>描述</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>恢復默認</translation>
+        <translation type="vanished">恢復默認</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>主題</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>淺色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>跟隨系統</translation>
     </message>

--- a/src/translations/dtkdeclarative_zh_TW.ts
+++ b/src/translations/dtkdeclarative_zh_TW.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AboutAction</name>
     <message>
-        <location filename="../qml/AboutAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/AboutAction.qml" line="9"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
@@ -10,33 +12,56 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="83"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="74"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="97"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="88"/>
         <source>Homepage</source>
         <translation>首頁</translation>
     </message>
     <message>
-        <location filename="../qml/AboutDialog.qml" line="112"/>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="110"/>
         <source>Description</source>
         <translation>描述</translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="125"/>
+        <source>Acknowledgements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>Sincerely appreciate the %1 used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../qt6/src/qml/AboutDialog.qml" line="129"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HelpAction</name>
     <message>
-        <location filename="../qml/HelpAction.qml" line="10"/>
+        <location filename="../../qt6/src/qml/HelpAction.qml" line="10"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
 </context>
 <context>
+    <name>LicenseDialog</name>
+    <message>
+        <location filename="../../qt6/src/qml/LicenseDialog.qml" line="16"/>
+        <source>open-source software</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QuitAction</name>
     <message>
-        <location filename="../qml/QuitAction.qml" line="9"/>
+        <location filename="../../qt6/src/qml/QuitAction.qml" line="9"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -44,7 +69,7 @@
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="../qml/SearchEdit.qml" line="41"/>
+        <location filename="../../qt6/src/qml/SearchEdit.qml" line="42"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
@@ -52,63 +77,62 @@
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../qml/settings/SettingsDialog.qml" line="79"/>
         <source>Restore Defaults</source>
-        <translation>復原預設</translation>
+        <translation type="vanished">復原預設</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../qml/TextField.qml" line="71"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="84"/>
         <source>Copy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="78"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="91"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="85"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="98"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="91"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="105"/>
         <source>Select All</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="98"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="112"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/TextField.qml" line="105"/>
+        <location filename="../../qt6/src/qml/TextField.qml" line="119"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeMenu</name>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="11"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="11"/>
         <source>Theme</source>
         <translation>主題</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="23"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="23"/>
         <source>Light Theme</source>
         <translation>淺色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="29"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="29"/>
         <source>Dark Theme</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../qml/ThemeMenu.qml" line="35"/>
+        <location filename="../../qt6/src/qml/ThemeMenu.qml" line="35"/>
         <source>System Theme</source>
         <translation>跟隨系統</translation>
     </message>


### PR DESCRIPTION
1. Added new LicenseDialog.qml component for displaying open-source software licenses
2. Modified AboutDialog.qml to replace inline license text with link to license dialog
3. Updated DialogTitleBar.qml to support left content area for back navigation
4. Added DLicenseInfoProvider C++ class to parse and provide license information
5. Updated copyright years from 2022 to 2026 across modified files
6. Added LicenseDialog to QML resources and build system

Log: Added license dialog for displaying open-source software acknowledgements

feat: 添加许可证对话框并更新关于对话框

1. 新增 LicenseDialog.qml 组件用于显示开源软件许可证信息
2. 修改 AboutDialog.qml，将内联许可证文本替换为指向许可证对话框的链接
3. 更新 DialogTitleBar.qml 以支持左侧内容区域用于返回导航
4. 新增 DLicenseInfoProvider C++ 类用于解析和提供许可证信息
5. 将修改文件的版权年份从 2022 更新至 2026
6. 将 LicenseDialog 添加到 QML 资源和构建系统中

Log: 新增用于显示开源软件致谢的许可证对话框

PMS: TASK-387863