### PR TITLE
fix(dialog): improve DialogWindow blur effect with proper color handling

### DIFF
--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -22,7 +22,7 @@ Window {
     D.DWindow.enableBlurWindow: true
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint
     D.ColorSelector.family: D.Palette.CrystalColor
-    color: active ? D.DTK.palette.window : D.DTK.inactivePalette.window
+    color: D.DWindow.enableBlurWindow ? "transparent" : (active ? D.DTK.palette.window : D.DTK.inactivePalette.window)
     height: content.height
     width: content.width
 
@@ -32,6 +32,21 @@ Window {
     property alias palette : content.palette
     property real leftPadding: DS.Style.dialogWindow.contentHMargin
     property real rightPadding: DS.Style.dialogWindow.contentHMargin
+    
+    D.StyledBehindWindowBlur {
+        control: control
+        anchors.fill: parent
+        blendColor: {
+            if (valid) {
+                return DS.Style.control.selectColor(undefined,
+                    Qt.rgba(235 / 255.0, 235 / 255.0, 235 / 255.0, 0.6),
+                    Qt.rgba(10 / 255.0, 10 / 255.0, 10 / 255.0, 85 / 255.0))
+            }
+            return DS.Style.control.selectColor(undefined,
+                DS.Style.behindWindowBlur.lightNoBlurColor,
+                DS.Style.behindWindowBlur.darkNoBlurColor)
+        }
+    }
 
     Item {
         id: content
@@ -45,7 +60,7 @@ Window {
                 id: titleBar
                 z: D.DTK.TopOrder
                 sourceComponent: DialogTitleBar {
-                    enableInWindowBlendBlur: true
+                    enableInWindowBlendBlur: false
                     icon.name: control.icon
                     title: control.title
                 }
@@ -60,7 +75,7 @@ Window {
             }
         }
     }
-
+    
     onClosing: function(close) {
         // close can't reset sub control's hovered state. pms Bug:168405
         // if we need to close, we can add closing handler to set `close.acceped = true`


### PR DESCRIPTION
Set color to transparent when enableBlurWindow is true to properly render blur effect. Add StyledBehindWindowBlur component and adjust title bar blend settings.

当启用窗口模糊时，将颜色设为透明以正确渲染模糊效果。添加窗口背景模糊组件并调整标题栏混合设置。

Log: 优化DialogWindow窗口模糊效果，颜色自动适配透明设置
PMS: BUG-316567
Influence: 使用模糊窗口的对话框不再需要手动设置color为transparent，由框架自动处理。同时新增StyledBehindWindowBlur组件提供更好的背景模糊视觉效果。

## Summary by Sourcery

Improve DialogWindow blur appearance and background handling for dialogs using window blur.

Bug Fixes:
- Automatically set dialog window color to transparent when blur is enabled so blurred dialogs render correctly.

Enhancements:
- Introduce StyledBehindWindowBlur background component with theme-aware blend colors behind dialog content.
- Disable in-window title bar blend blur to work with the new behind-window blur behavior.