### PR TITLE
fix: prevent crashes from dangling pointers in destructors

### DIFF
--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -173,7 +173,8 @@ bool DQuickWindowAttachedPrivate::ensurePlatformHandle()
 
 void DQuickWindowAttachedPrivate::destoryPlatformHandle()
 {
-    handle->setEnabledNoTitlebarForWindow(window, false);
+    if (window)
+        handle->setEnabledNoTitlebarForWindow(window, false);
     delete handle;
     handle = nullptr;
 }
@@ -1025,7 +1026,7 @@ void DQuickWindowAttached::setClipPath(QQuickPath *path)
 
 bool DQuickWindowAttached::eventFilter(QObject *watched, QEvent *event)
 {
-    if (watched == parent()) {
+    if (watched == window()) {
         if (event->type() == QEvent::PlatformSurface) {
             QPlatformSurfaceEvent *surface = static_cast<QPlatformSurfaceEvent *>(event);
             if (surface->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated) {
@@ -1045,6 +1046,8 @@ void DQuickWindowAttached::setAlphaBufferSize(int size)
         return;
 
     QQuickWindow *w = window();
+    if (!w)
+        return;
     QSurfaceFormat fmt = w->requestedFormat();
     fmt.setAlphaBufferSize(size);
     w->setFormat(fmt);

--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -66,10 +66,14 @@ static inline bool _d_isWindowRootItem(QQuickItem *item) {
 // `qvariant_cast` gets application's palette, and `toQPalette` gets root window's
 // palette.
 static inline QPalette _d_getControlPalette(QQuickItem *item) {
+    if (!item)
+        return QPalette();
+
     const QVariant &palette = item->property("palette");
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const QQuickPalette *pa = palette.value<QQuickPalette *>();
-    Q_ASSERT(pa);
+    if (!pa)
+        return QPalette();
     return pa->toQPalette();
 #else
     return qvariant_cast<QPalette>(palette);
@@ -467,6 +471,10 @@ void DQuickControlColorSelector::setControl(QQuickItem *newControl)
         auto palette = m_control->property("palette").value<QQuickPalette*>();
         connect(palette, &QQuickPalette::changed, this, &DQuickControlColorSelector::updateControlTheme);
 #endif
+        connect(m_control, &QObject::destroyed, this, [this] {
+            m_controlWindow = nullptr;
+            m_control = nullptr;
+        });
         if (m_control->metaObject()->indexOfSignal("paletteChanged()") != -1) {
             connect(m_control, SIGNAL(paletteChanged()), this, SLOT(updateControlTheme()));
         }
@@ -1086,12 +1094,13 @@ void DQuickControlColorSelector::onPaletteDestroyed()
 
 void DQuickControlColorSelector::updateControlWindow()
 {
-    if (m_controlWindow == m_control->window())
+    QQuickWindow *window = m_control ? m_control->window() : nullptr;
+    if (m_controlWindow == window)
         return;
     if (m_controlWindow) {
         m_controlWindow->disconnect(this);
     }
-    m_controlWindow = m_control->window();
+    m_controlWindow = window;
     if (m_controlWindow) {
         connect(m_controlWindow, &QQuickWindow::activeChanged,
                 this, &DQuickControlColorSelector::updateControlState);

--- a/src/private/dquickcontrolpalette_p.h
+++ b/src/private/dquickcontrolpalette_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -370,8 +370,8 @@ private:
     void setSuperColorSelector(DQuickControlColorSelector *parent);
     void setFamilyPropertyParent(DQuickControlColorSelector *parent);
 
-    QQuickItem *m_control = nullptr;
-    QQuickWindow *m_controlWindow = nullptr;
+    QPointer<QQuickItem> m_control;
+    QPointer<QQuickWindow> m_controlWindow;
     QPointer<DQuickControlColorSelector> m_superColorSelector;
     QPointer<DQuickControlColorSelector> m_parentOfFamilyProperty;
     typedef QPair<QByteArray, DQuickControlPalette*> ControlPaletteData;

--- a/src/private/dquickwindow_p.h
+++ b/src/private/dquickwindow_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,8 @@
 #include <DObjectPrivate>
 #include <DObject>
 #include <DPlatformHandle>
+
+#include <QPointer>
 
 #include "dquickwindow.h"
 
@@ -52,7 +54,7 @@ public:
     void _q_onPaletteChanged();
 #endif
 
-    QWindow *window = nullptr;
+    QPointer<QWindow> window = nullptr;
     DPlatformHandle *handle = nullptr;
     BoolOptional explicitEnable {Invalid};
     BoolOptional explicitTranslucentBackground {Invalid};


### PR DESCRIPTION
1. Fixed null pointer dereference in
DQuickWindowAttachedPrivate::destoryPlatformHandle() by adding null
check before calling setEnabledNoTitlebarForWindow
2. Fixed event filter in DQuickWindowAttached to use window() instead of
parent() to avoid accessing destroyed parent object
3. Added null check for window in
DQuickWindowAttached::setAlphaBufferSize() to prevent accessing
destroyed window
4. Added null checks in DQuickControlColorSelector palette handling to
prevent crashes when items are destroyed
5. Added connection to QObject::destroyed signal to clear control and
window pointers when control is destroyed
6. Changed m_control and m_controlWindow from raw pointers to QPointer
for automatic nullification
7. Changed DQuickWindowAttachedPrivate::window from raw pointer to
QPointer to prevent dangling pointer access

Log: Fixed crashes caused by accessing destroyed objects during window
and palette cleanup

Influence:
1. Test window destruction scenarios to ensure no crashes occur
2. Verify palette functionality still works correctly with valid
controls
3. Test window resize and minimize operations after palette changes
4. Verify alpha buffer size setting works with valid windows
5. Test rapid creation and destruction of windows with custom palettes
6. Verify no memory leaks occur with repeated window creation/
destruction

fix: 修复析构导致的野指针崩溃问题

1. 在 DQuickWindowAttachedPrivate::destoryPlatformHandle() 中添加空指针
检查，避免在调用 setEnabledNoTitlebarForWindow 时访问已销毁对象
2. 修复 DQuickWindowAttached 中的事件过滤器，使用 window() 替代 parent()
避免访问已销毁的父对象
3. 在 DQuickWindowAttached::setAlphaBufferSize() 中添加窗口空指针检查，
防止访问已销毁的窗口
4. 在 DQuickControlColorSelector 调色板处理中添加空指针检查，防止控件销
毁时崩溃
5. 添加 QObject::destroyed 信号连接，在控件销毁时清除控制和窗口指针
6. 将 m_control 和 m_controlWindow 从原始指针改为 QPointer，实现自动置空
7. 将 DQuickWindowAttachedPrivate::window 从原始指针改为 QPointer，防止
悬垂指针访问

Log: 修复了窗口和调色板清理过程中访问已销毁对象导致的崩溃问题

Influence:
1. 测试窗口销毁场景，确保不会发生崩溃
2. 验证调色板功能在有效控件下仍能正常工作
3. 测试窗口调整大小和最小化操作后的调色板变化
4. 验证 alpha 缓冲区大小设置在有效窗口下正常工作
5. 测试快速创建和销毁带有自定义调色板的窗口
6. 验证重复窗口创建/销毁不会导致内存泄漏

## Summary by Sourcery

Prevent crashes caused by accessing destroyed window and control objects during window and palette handling.

Bug Fixes:
- Guard window platform handle teardown and alpha buffer configuration against null windows to avoid dereferencing destroyed window objects.
- Use the attached window instead of the parent object in the event filter to avoid handling events on already-destroyed parents.
- Add null checks when resolving control palettes and QQuickPalette instances to avoid crashes when controls or palettes are missing or destroyed.
- Connect to control destruction to clear cached control and window references, preventing use-after-free in color selector logic.

Enhancements:
- Replace raw pointers to controls, windows, and attached windows with QPointer to automatically nullify references when underlying Qt objects are destroyed.