### PR TITLE
fix: write maskOffset to the correct uniform buffer offset

### DIFF
--- a/src/private/dmaskeffectnode.cpp
+++ b/src/private/dmaskeffectnode.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -200,7 +200,7 @@ bool OpaqueTextureMaterialShader::updateUniformData(RenderState &state, QSGMater
         Q_ASSERT(sizeof(maskScale) == MaskScaleSize);
 
         memcpy(buf->data() + MaskScaleOffset, &maskScale, MaskScaleSize);
-        memcpy(buf->data() + MaskOffsetSize, &maskOffset, MaskOffsetSize);
+        memcpy(buf->data() + MaskOffsetOffset, &maskOffset, MaskOffsetSize);
         memcpy(buf->data() + SourceScaleOffset, &sourceScale, SourceScaleSize);
 
         changed = true;


### PR DESCRIPTION
Use MaskOffsetOffset instead of MaskOffsetSize when updating the Qt 6 opaque quickitemviewport uniform buffer. The previous code wrote maskOffset using a size constant as the destination offset, which does not match the shader ubuf layout and can corrupt the following uniform data.

Log: Fix maskOffset uniform buffer write offset in Qt 6 mask effect shader

fix: 修复 maskOffset 写入错误的 uniform buffer 偏移

在更新 Qt 6 的 opaque quickitemviewport uniform buffer 时，使用正确的 MaskOffsetOffset 而不是 MaskOffsetSize。旧代码把大小常量误用成目标偏移， 与 shader 的 ubuf 布局不一致，并可能破坏后续 uniform 数据。

Log: 修复 Qt 6 mask effect shader 中 maskOffset 的 uniform buffer 写入偏移

PMS: BUG-306847

PS：GPT-5.4发现的一个单独问题，如果确认是判断错误的话，直接备注关掉就行。