### PR TITLE
fix: avoid double alpha multiplication in rounded popup mask

### DIFF
--- a/qt6/src/shaders_ng/quickitemviewport-opaque.frag
+++ b/qt6/src/shaders_ng/quickitemviewport-opaque.frag
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -44,7 +44,9 @@ void main()
         discard;
 
     lowp vec4 tex = texture(qt_Texture, qt_TexCoord);
-    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
+    // The input texture is already premultiplied. Multiplying by tex.a again
+    // darkens the partially covered edge pixels and makes corner artifacts more
+    // visible on transparent windows under fractional scaling.
     tex *= mask_tex;
-    fragColor = tex * tex.a;
+    fragColor = tex;
 }

--- a/qt6/src/shaders_ng/quickitemviewport.frag
+++ b/qt6/src/shaders_ng/quickitemviewport.frag
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -46,7 +46,9 @@ void main()
 
     lowp vec4 tex = texture(qt_Texture, qt_TexCoord);
 
-    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
+    // The input texture is already premultiplied. Multiplying by tex.a again
+    // darkens the partially covered edge pixels and makes corner artifacts more
+    // visible on transparent windows under fractional scaling.
     tex *= mask_top_left * mask_bottom_left * mask_top_right * mask_bottom_right;
-    fragColor = tex * tex.a * ubuf.opacity;
+    fragColor = tex * ubuf.opacity;
 }


### PR DESCRIPTION
Keep premultiplied alpha output in the Qt 6 ItemViewport rounded mask shaders. The popup panel texture is already premultiplied when captured from QSGLayer. Multiplying by tex.a again darkens partially covered corner pixels and makes black dots visible on transparent popup corners under fractional scaling such as 125%.

Log: Fix black dots at popup rounded corners under fractional scaling

fix: 修复弹窗圆角遮罩重复乘 alpha 问题

在 Qt 6 的 ItemViewport 圆角遮罩 shader 中保持正确的 premultiplied alpha 输出。弹窗面板纹理在从 QSGLayer 抓取后已经是 premultiplied，再乘一次 tex.a 会把圆角边缘的半覆盖像素压暗，导致 125% 等分数缩放下透明弹窗圆角出现黑点。

Log: 修复分数缩放下弹窗圆角黑点问题

PMS: BUG-306847