### PR TITLE
fix: correct border width for high DPI scaling in FloatingPanel

### DIFF
--- a/qt6/src/qml/FloatingPanel.qml
+++ b/qt6/src/qml/FloatingPanel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -85,7 +85,7 @@ Control {
             sourceComponent: InsideBoxBorder {
                 radius: backgroundRect.radius
                 color: control.D.ColorSelector.insideBorderColor
-                borderWidth: DS.Style.control.borderWidth
+                borderWidth: DS.Style.control.borderWidth / Screen.devicePixelRatio
             }
         }
 
@@ -95,7 +95,7 @@ Control {
             sourceComponent: OutsideBoxBorder {
                 radius: backgroundRect.radius
                 color: control.D.ColorSelector.outsideBorderColor
-                borderWidth: DS.Style.control.borderWidth
+                borderWidth: DS.Style.control.borderWidth / Screen.devicePixelRatio
             }
         }
     }


### PR DESCRIPTION
Divide borderWidth by Screen.devicePixelRatio to ensure consistent border appearance across different display scaling factors.

修复 FloatingPanel 在高DPI缩放下边框宽度不正确的问题

将边框宽度除以 Screen.devicePixelRatio，确保在不同显示缩放
比例下边框外观保持一致。

PMS: BUG-306847

## Summary by Sourcery

Adjust FloatingPanel border rendering for correct appearance on high-DPI displays.

Bug Fixes:
- Correct inconsistent FloatingPanel border thickness on high-DPI scaling.

Enhancements:
- Update SPDX copyright header years in FloatingPanel QML file.