### PR TITLE
fix: use mask alpha channel for blending in ItemViewport shaders

### DIFF
--- a/qt6/src/shaders_ng/quickitemviewport-opaque.frag
+++ b/qt6/src/shaders_ng/quickitemviewport-opaque.frag
@@ -44,9 +44,6 @@ void main()
         discard;
 
     lowp vec4 tex = texture(qt_Texture, qt_TexCoord);
-    // The input texture is already premultiplied. Multiplying by tex.a again
-    // darkens the partially covered edge pixels and makes corner artifacts more
-    // visible on transparent windows under fractional scaling.
-    tex *= mask_tex;
-    fragColor = tex;
+
+    fragColor = tex * mask_tex.a;
 }

--- a/qt6/src/shaders_ng/quickitemviewport.frag
+++ b/qt6/src/shaders_ng/quickitemviewport.frag
@@ -46,9 +46,5 @@ void main()
 
     lowp vec4 tex = texture(qt_Texture, qt_TexCoord);
 
-    // The input texture is already premultiplied. Multiplying by tex.a again
-    // darkens the partially covered edge pixels and makes corner artifacts more
-    // visible on transparent windows under fractional scaling.
-    tex *= mask_top_left * mask_bottom_left * mask_top_right * mask_bottom_right;
-    fragColor = tex * ubuf.opacity;
+    fragColor = tex * mask_tex.a * ubuf.opacity;
 }


### PR DESCRIPTION
Simplify the mask blending logic in quickitemviewport shaders by using only the mask's alpha channel instead of multiplying with the entire mask color. This ensures correct color output when the mask texture contains non-neutral RGB values and maintains consistency with the expected premultiplied alpha behavior.

Log: Fix mask blending to use alpha channel only in ItemViewport shaders

fix: 修复 ItemViewport shader 中 mask 混合逻辑

简化 quickitemviewport shader 中的 mask 混合逻辑，仅使用 mask 的 alpha 通道 而非整个 mask 颜色值进行混合。这确保了当 mask 纹理包含非中性 RGB 值时输出
颜色正确，并与预期的 premultiplied alpha 行为保持一致。

Log: 修复 ItemViewport shader 中 mask 混合应仅使用 alpha 通道

PMS: BUG-306847

## Summary by Sourcery

Bug Fixes:
- Fix incorrect color output in ItemViewport shaders by basing mask blending solely on the mask texture alpha channel instead of the full mask color.