### PR TITLE
fix(slider): adjust path calculation for handle alignment

### DIFF
--- a/qt6/src/qml/Slider.qml
+++ b/qt6/src/qml/Slider.qml
@@ -100,7 +100,7 @@ T.Slider {
                         startX: control.horizontal ? (control.alignToTicks ? __handle.width / 2 : 0) : sliderGroove.width / 2
                         startY: control.horizontal ? sliderGroove.height / 2 : sliderGroove.height
                         PathLine {
-                            x: control.horizontal ? control.handle.x : sliderGroove.width / 2
+                            x: control.horizontal ? ((control.handleType < 0 && control.handle.x > 0) ? control.handle.x + control.handle.width : control.handle.x) : sliderGroove.width / 2
                             y: control.horizontal ? sliderGroove.height / 2 : control.handle.y + control.handle.height / 2
                         }
                     }


### PR DESCRIPTION
When handleType is less than 0 and x-value more than 0, the x-coordinate calculation now includes the handle width offset to correct the visual alignment of the slider path.

Log: adjust path calculation for handle alignment
PMS: BUG-358623
Influence: 检查输入设备的反馈音量显示是否正确，同时关注静音场景（PMS:350837）

## Summary by Sourcery

Bug Fixes:
- Fix misalignment between the slider handle and the rendered path when using negative handle types with positive x-coordinates.