### PR TITLE
fix(slider): adjust path calculation for handle alignment

### DIFF
--- a/qt6/src/qml/Slider.qml
+++ b/qt6/src/qml/Slider.qml
@@ -17,7 +17,8 @@ T.Slider {
         ArrowUp = 2,
         ArrowLeft = 3,
         ArrowBottom = 4,
-        ArrowRight = 5
+        ArrowRight = 5,
+        NoArrowType = 6
     }
 
     property D.Palette grooveColor: DS.Style.slider.groove.background
@@ -100,16 +101,29 @@ T.Slider {
                         startX: control.horizontal ? (control.alignToTicks ? __handle.width / 2 : 0) : sliderGroove.width / 2
                         startY: control.horizontal ? sliderGroove.height / 2 : sliderGroove.height
                         PathLine {
-                            x: control.horizontal ? control.handle.x : sliderGroove.width / 2
-                            y: control.horizontal ? sliderGroove.height / 2 : control.handle.y + control.handle.height / 2
+                            x: control.horizontal ? (control.handleType === Slider.HandleType.NoArrowType
+                                                       ? control.visualPosition * sliderGroove.width
+                                                       : control.handle.x) : sliderGroove.width / 2
+                            y: control.horizontal ? sliderGroove.height / 2
+                                                         : (control.handleType === Slider.HandleType.NoArrowType
+                                                            ? control.visualPosition * sliderGroove.height
+                                                            : control.handle.y + control.handle.height / 2)
                         }
                     }
 
                     Item {
                         id: passItem
-                        y: control.horizontal ? -DS.Style.slider.groove.height / 2 : control.handle.y + control.handle.height / 2
-                        height: control.horizontal ? DS.Style.slider.groove.height : sliderGroove.height - control.handle.y - control.handle.height / 2
-                        width: control.horizontal ? control.handle.x : DS.Style.slider.groove.height
+                        y: control.horizontal ? -DS.Style.slider.groove.height / 2
+                                                : (control.handleType === Slider.HandleType.NoArrowType
+                                                   ? control.visualPosition * sliderGroove.height
+                                                   : control.handle.y + control.handle.height / 2)
+                        height: control.horizontal ? DS.Style.slider.groove.height
+                                                    : (control.handleType === Slider.HandleType.NoArrowType
+                                                      ? sliderGroove.height - control.visualPosition * sliderGroove.height
+                                                      : sliderGroove.height - control.handle.y - control.handle.height / 2)
+                        width: control.horizontal ? (control.handleType === Slider.HandleType.NoArrowType 
+                                                    ? control.visualPosition * sliderGroove.width 
+                                                    : control.handle.x) : DS.Style.slider.groove.height
                     }
 
                     BoxShadow {


### PR DESCRIPTION
When handleType is NoHandleType, the x-coordinate calculation now calculates based on sliderGroove to correct the visual alignment of the slider path.

Log: adjust path calculation for handle alignment
PMS: BUG-358623
Influence: 检查输入设备的反馈音量显示是否正确，同时关注静音场景（PMS:350837）

## Summary by Sourcery

Adjust slider path and pass region calculations to keep the filled track visually aligned when using a handle-less slider variant.

Bug Fixes:
- Fix misaligned slider path rendering when the handle type is set to a handle-less (NoArrowType) configuration.

Enhancements:
- Introduce a NoArrowType handle type to support sliders rendered without a visible handle while retaining correct positioning logic.