### PR TITLE
fix: remove the hardcoded font size in the HTML

### DIFF
--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -25,7 +25,7 @@ DialogWindow {
     property string websiteLink
 
     readonly property string __websiteLinkTemplate:
-        "<a href='%1' style='text-decoration: none; font-size:13px; color: #004EE5;'>%2</a>"
+        "<a href='%1' style='text-decoration: none; color: #004EE5;'>%2</a>"
 
     RowLayout {
         id: contentView


### PR DESCRIPTION
1. Remove font size from the website link style in AboutDialog
2. Allow the link text to inherit the default font size

Log: Remove hardcoded font-size from AboutDialog website link style

fix: 移除HTML中硬编码的字体大小

1. 移除 AboutDialog 中网站链接样式
2. 允许链接文字继承默认字体大小

Log: 移除关于对话框网站链接样式中硬编码的字体大小
PMS: BUG-361035

## Summary by Sourcery

Bug Fixes:
- Allow the About dialog website link text to inherit the default font size instead of using a hardcoded 13px value.