### PR TITLE
fix: hide hyperlink when license path is invalid

### DIFF
--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -31,6 +31,12 @@ DialogWindow {
         id: contentView
         width: parent.width
         implicitHeight: contentLayout.implicitHeight
+
+        D.LicenseInfoProvider {
+            id: licensePathChecker
+            path: control.licensePath
+        }
+        
         ColumnLayout {
             id: contentLayout
             spacing: 0
@@ -138,7 +144,13 @@ DialogWindow {
                 }
                 Label {
                     id: acknowledgmentsLabel
-                    text: qsTr("Sincerely appreciate the %1 used.").arg(control.__websiteLinkTemplate.arg("-").arg(qsTr("open-source software")))
+                    text: {
+                        var softwareText = qsTr("open-source software");
+                        if (licensePathChecker.valid)
+                            return qsTr("Sincerely appreciate the %1 used.").arg(control.__websiteLinkTemplate.arg("-").arg(softwareText));
+                        else
+                            return qsTr("Sincerely appreciate the %1 used.").arg(softwareText);
+                    }
                     textFormat: Text.RichText
                     Layout.fillWidth: true
                     font: D.DTK.fontManager.t8
@@ -173,7 +185,7 @@ DialogWindow {
         id: licenseDialogLoader
         active: false
         sourceComponent: LicenseDialog {
-            licensePath: control.licensePath
+            licenseProvider: licensePathChecker
             onClosing: function (close) {
                 licenseDialogLoader.active = false
             }

--- a/qt6/src/qml/LicenseDialog.qml
+++ b/qt6/src/qml/LicenseDialog.qml
@@ -15,7 +15,7 @@ DialogWindow {
     height: 900
     title: qsTr("open-source software")
 
-    property alias licensePath: licenseProvider.path
+    property D.LicenseInfoProvider licenseProvider
 
     header: D.DialogTitleBar {
         leftContent: Item {
@@ -36,10 +36,6 @@ DialogWindow {
     Item {
         implicitWidth: control.width - control.leftPadding - control.rightPadding
         implicitHeight: control.height - DS.Style.dialogWindow.titleBarHeight - DS.Style.dialogWindow.contentHMargin
-
-        D.LicenseInfoProvider {
-            id: licenseProvider
-        }
 
         StackView {
             id: stackView


### PR DESCRIPTION
1. Add D.LicenseInfoProvider to check if the license path is valid
2. Conditionally render the open-source software text with or without hyperlink
3. Set textFormat to RichText or PlainText based on license path validity

Log: Hide the open-source software hyperlink in the about dialog when license path is invalid

fix: 许可证路径无效时隐藏超链接

1. 添加 D.LicenseInfoProvider 检查许可证路径是否有效
2. 根据许可证路径有效性决定是否渲染开源软件超链接
3. 根据许可证路径有效性设置 textFormat 为 RichText 或 PlainText

Log: 关于对话框中许可证路径无效时隐藏开源软件超链接
PMS: BUG-361031