### PR TITLE
fix: fix content truncation with scrollable view

### DIFF
--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -4,6 +4,7 @@
 
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls
 import QtQuick.Window
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
@@ -12,6 +13,8 @@ DialogWindow {
     id: control
     width: DS.Style.aboutDialog.width
     height: DS.Style.aboutDialog.height
+    topPadding: 0
+    rightPadding: 0
 
     property alias windowTitle: control.title
     property alias productName: productNameLabel.text
@@ -30,7 +33,7 @@ DialogWindow {
     RowLayout {
         id: contentView
         width: parent.width
-        implicitHeight: contentLayout.implicitHeight
+        height: control.height - DS.Style.dialogWindow.titleBarHeight
 
         D.LicenseInfoProvider {
             id: licensePathChecker
@@ -79,94 +82,109 @@ DialogWindow {
                 visible: control.license !== ""
             }
         }
-        ColumnLayout {
+        Flickable {
+            id: rightContentView
+            ScrollBar.vertical: ScrollBar {}
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-            spacing: 10
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.rightMargin: 20
-            ColumnLayout {
-                spacing: 1
-                Label {
-                    font: D.DTK.fontManager.t10
-                    text: qsTr("Version")
-                }
-                Label {
-                    id: versionLabel
-                    font: D.DTK.fontManager.t8
-                    wrapMode: Text.WordWrap
-                    text: Qt.application.version
-                    Layout.fillWidth: true
-                }
-            }
-            ColumnLayout {
-                spacing: 1
-                Label {
-                    font: D.DTK.fontManager.t10
-                    text: qsTr("Homepage")
-                }
-                Label {
-                    id: websiteLabel
-                    font: D.DTK.fontManager.t8
-                    textFormat: Text.RichText
-                    text: (control.websiteLink === "" || control.websiteName === "") ?
-                              "" : control.__websiteLinkTemplate.arg(websiteLink).arg(control.websiteName)
-                    wrapMode: Text.WordWrap
-                    Layout.fillWidth: true
+            clip: true
+            contentWidth: width
+            contentHeight: rightContentLayout.height
+            boundsBehavior: Flickable.StopAtBounds
+            flickableDirection: Flickable.VerticalFlick
 
-                    MouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        acceptedButtons: Qt.NoButton
+            Item {
+                ColumnLayout {
+                    id: rightContentLayout
+                    width: rightContentView.width
+                    spacing: 10
+
+                    ColumnLayout {
+                        spacing: 1
+                        Label {
+                            font: D.DTK.fontManager.t10
+                            text: qsTr("Version")
+                        }
+                        Label {
+                            id: versionLabel
+                            font: D.DTK.fontManager.t8
+                            wrapMode: Text.WordWrap
+                            text: Qt.application.version
+                            Layout.fillWidth: true
+                        }
                     }
-                }
-            }
-            ColumnLayout {
-                spacing: 1
-                Label {
-                    font: D.DTK.fontManager.t10
-                    text: qsTr("Description")
-                }
-                Label {
-                    id: descriptionLabel
-                    Layout.fillWidth: true
-                    font: D.DTK.fontManager.t8
-                    wrapMode: Text.WordWrap
+                    ColumnLayout {
+                        spacing: 1
+                        Label {
+                            font: D.DTK.fontManager.t10
+                            text: qsTr("Homepage")
+                        }
+                        Label {
+                            id: websiteLabel
+                            font: D.DTK.fontManager.t8
+                            textFormat: Text.RichText
+                            text: (control.websiteLink === "" || control.websiteName === "") ?
+                                      "" : control.__websiteLinkTemplate.arg(websiteLink).arg(control.websiteName)
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                acceptedButtons: Qt.NoButton
+                            }
+                        }
+                    }
+                    ColumnLayout {
+                        spacing: 1
+                        Label {
+                            font: D.DTK.fontManager.t10
+                            text: qsTr("Description")
+                        }
+                        Label {
+                            id: descriptionLabel
+                            Layout.fillWidth: true
+                            font: D.DTK.fontManager.t8
+                            wrapMode: Text.WordWrap
                     elide: Text.ElideRight
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.bottomMargin: 30
+                        spacing: 1
+                        Label {
+                            font: D.DTK.fontManager.t10
+                            text: qsTr("Acknowledgements")
+                        }
+                        Label {
+                            id: acknowledgmentsLabel
+                            text: {
+                                var softwareText = qsTr("open-source software");
+                                if (licensePathChecker.valid)
+                                    return qsTr("Sincerely appreciate the %1 used.").arg(control.__websiteLinkTemplate.arg("-").arg(softwareText));
+                                else
+                                    return qsTr("Sincerely appreciate the %1 used.").arg(softwareText);
+                            }
+                            textFormat: Text.RichText
+                            Layout.fillWidth: true
+                            font: D.DTK.fontManager.t8
+                            wrapMode: Text.WordWrap
+                            elide: Text.ElideRight
+
+                            onLinkActivated: function(link) {
+                                licenseDialogLoader.active = true
+                            }
+
+                            HoverHandler {
+                                cursorShape: acknowledgmentsLabel.hoveredLink !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            }
+                        }
+                    }
                 }
             }
-
-            ColumnLayout {
-                spacing: 1
-                Label {
-                    font: D.DTK.fontManager.t10
-                    text: qsTr("Acknowledgements")
-                }
-                Label {
-                    id: acknowledgmentsLabel
-                    text: {
-                        var softwareText = qsTr("open-source software");
-                        if (licensePathChecker.valid)
-                            return qsTr("Sincerely appreciate the %1 used.").arg(control.__websiteLinkTemplate.arg("-").arg(softwareText));
-                        else
-                            return qsTr("Sincerely appreciate the %1 used.").arg(softwareText);
-                    }
-                    textFormat: Text.RichText
-                    Layout.fillWidth: true
-                    font: D.DTK.fontManager.t8
-                    wrapMode: Text.WordWrap
-                    elide: Text.ElideRight
-
-                    onLinkActivated: function(link) {
-                        licenseDialogLoader.active = true
-                    }
-
-                    HoverHandler {
-                        cursorShape: acknowledgmentsLabel.hoveredLink !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-                }
-            }
-       }
+        }
 
         Component.onCompleted: {
             websiteLabel.linkActivated.connect(D.ApplicationHelper.openUrl)

--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -66,12 +66,17 @@ Window {
                 }
             }
 
-            D.Label {
-                text: control.title
+            Loader {
+                active: title !== ""
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
-                elide: Text.ElideRight
-                horizontalAlignment: Text.AlignHCenter
+                sourceComponent: Component {
+                    D.Label {
+                        text: control.title
+                        elide: Text.ElideRight
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+                }
             }
 
             Item {


### PR DESCRIPTION
1. Wrap the right content area in a Flickable to support vertical scrolling
2. Add ScrollBar with AsNeeded policy for long content overflow
3. Remove elide mode from description and acknowledgements labels
4. Adjust layout margins for better content display

Log: Make AboutDialog content scrollable to prevent truncation

fix: 修复关于对话框内容截断问题

1. 将右侧内容区域包裹在 Flickable 中支持垂直滚动
2. 添加 ScrollBar 滚动条以处理长内容溢出
3. 移除描述和致谢标签的省略模式
4. 调整布局边距以改善内容显示

Log: 使关于对话框内容可滚动，防止内容被截断
PMS: BUG-361037