### PR TITLE
fix: remove top padding when title is empty

### DIFF
--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -32,7 +32,7 @@ Window {
     property alias palette : content.palette
     property real leftPadding: DS.Style.dialogWindow.contentHMargin
     property real rightPadding: DS.Style.dialogWindow.contentHMargin
-    property real topPadding: DS.Style.dialogWindow.contentVMargin
+    property real topPadding: title === "" ? 0 : DS.Style.dialogWindow.contentVMargin
     
     D.StyledBehindWindowBlur {
         control: control


### PR DESCRIPTION
1. Set topPadding to 0 when the dialog title is empty string
2. Apply default contentVMargin only when a title is present
3. Fix visual alignment issue for dialogs without titles

Log: Hide top padding for title-less dialogs to fix layout

fix: 无标题时移除顶部内边距

1. 当对话框标题为空时，将 topPadding 设为 0
2. 仅在有标题时应用默认的 contentVMargin
3. 修复无标题对话框的视觉对齐问题

Log: 无标题对话框隐藏顶部内边距以修复布局
PMS: BUG-362237

## Summary by Sourcery

Bug Fixes:
- Remove top padding when dialog title is empty to fix visual misalignment of title-less dialogs.