### PR TITLE
refactor: replace private access hacks with accessor pattern

### DIFF
--- a/src/private/dbackdropnode.cpp
+++ b/src/private/dbackdropnode.cpp
@@ -1,17 +1,14 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <QDebug>
-#define protected public
-#define private public
 #include <rhi/qrhi.h>
 #include <private/qsgrenderer_p.h>
-#undef protected
-#undef private
 
 #include "dbackdropnode_p.h"
 #include "dqmlglobalobject_p.h"
+#include "util/dprivateaccessor_p.h"
 
 #include <QQuickItem>
 #include <QRunnable>
@@ -33,6 +30,33 @@
 #endif
 
 #include <algorithm>
+
+#ifndef QT_NO_OPENGL
+D_DECLARE_PRIVATE_MEMBER(QRhi_d_tag, QRhi, d, QRhiImplementation*);
+#endif
+
+// QSGRenderer keeps m_changed_emitted/m_is_rendering as private bit-fields
+// right after m_nodes_dont_preprocess, matching the layout used in Waylib.
+D_DECLARE_PRIVATE_METHOD(QSGRenderer_preprocess_tag, QSGRenderer, preprocess, void);
+D_DECLARE_PRIVATE_METHOD(QSGRenderer_render_tag, QSGRenderer, render, void);
+D_DECLARE_PRIVATE_BITFIELD(QSGRenderer_m_nodes_dont_preprocess_tag,
+                           QSGRenderer, m_nodes_dont_preprocess,
+                           QSet<QSGNode *>, uint);
+static constexpr unsigned k_m_changed_emitted_bit = 0;
+static constexpr unsigned k_m_is_rendering_bit = 1;
+
+static_assert(sizeof(QSGRenderer) == 432,
+              "QSGRenderer size changed — review qsgrenderer_p.h and update the bit-field accessor");
+
+static inline void rendererPreprocess(QSGRenderer *renderer)
+{
+    D_PRIVATE_CALL(*renderer, QSGRenderer_preprocess_tag{});
+}
+
+static inline void rendererRender(QSGRenderer *renderer)
+{
+    D_PRIVATE_CALL(*renderer, QSGRenderer_render_tag{});
+}
 
 DQUICK_BEGIN_NAMESPACE
 
@@ -360,7 +384,7 @@ public:
         QRhiGles2 *gles2Rhi = nullptr;
         if (forceSurface) {
             Q_ASSERT(rhi()->backend() == QRhi::OpenGLES2);
-            gles2Rhi = static_cast<QRhiGles2*>(rhi()->d);
+            gles2Rhi = static_cast<QRhiGles2*>(D_PRIVATE_MEMBER(*rhi(), QRhi_d_tag{}));
             fallbackSurface = gles2Rhi->fallbackSurface;
             gles2Rhi->fallbackSurface = forceSurface;
         }
@@ -383,17 +407,17 @@ public:
         oldCB = dc->currentFrameCommandBuffer();
         context->prepareSync(renderer->devicePixelRatio(), cb, graphicsConfiguration());
 
-        renderer->m_is_rendering = true;
-        renderer->preprocess();
+        D_PRIVATE_BF_SET(*renderer, QSGRenderer_m_nodes_dont_preprocess_tag, k_m_is_rendering_bit, true);
+        rendererPreprocess(renderer);
 
         return true;
     }
 
     bool render(qreal oldDPR, QRhiCommandBuffer* &oldCB) {
-        Q_ASSERT(renderer->m_is_rendering);
-        renderer->render();
-        renderer->m_is_rendering = false;
-        renderer->m_changed_emitted = false;
+        Q_ASSERT(D_PRIVATE_BF_GET(*renderer, QSGRenderer_m_nodes_dont_preprocess_tag, k_m_is_rendering_bit));
+        rendererRender(renderer);
+        D_PRIVATE_BF_SET(*renderer, QSGRenderer_m_nodes_dont_preprocess_tag, k_m_is_rendering_bit, false);
+        D_PRIVATE_BF_SET(*renderer, QSGRenderer_m_nodes_dont_preprocess_tag, k_m_changed_emitted_bit, false);
 
         context->prepareSync(oldDPR, oldCB, graphicsConfiguration());
 

--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#define private public
 #include <QSGNode>
-#undef private
 
 #include "dqmlglobalobject_p.h"
 #include "dqmlglobalobject_p_p.h"
+#include "util/dprivateaccessor_p.h"
 #include "dquickcontrolpalette_p.h"
 #include "dquickdciicon_p.h"
 #include "dquickimageprovider_p.h"
@@ -36,6 +35,11 @@
 #endif
 
 DGUI_USE_NAMESPACE
+
+D_DECLARE_PRIVATE_MEMBER(QSGNode_m_subtreeRenderableCount_tag, QSGNode, m_subtreeRenderableCount, int);
+D_DECLARE_PRIVATE_MEMBER(QSGNode_m_firstChild_tag, QSGNode, m_firstChild, QSGNode *);
+D_DECLARE_PRIVATE_MEMBER(QSGNode_m_lastChild_tag, QSGNode, m_lastChild, QSGNode *);
+D_DECLARE_PRIVATE_MEMBER(QSGNode_m_parent_tag, QSGNode, m_parent, QSGNode *);
 
 DQUICK_BEGIN_NAMESPACE
 
@@ -556,22 +560,22 @@ QSGRootNode *DQMLGlobalObject::getRootNode(QQuickItem *item)
 
 int &DQMLGlobalObject::QSGNode_subtreeRenderableCount(QSGNode *node)
 {
-    return node->m_subtreeRenderableCount;
+    return D_PRIVATE_MEMBER(*node, QSGNode_m_subtreeRenderableCount_tag{});
 }
 
 QSGNode *&DQMLGlobalObject::QSGNode_firstChild(QSGNode *node)
 {
-    return node->m_firstChild;
+    return D_PRIVATE_MEMBER(*node, QSGNode_m_firstChild_tag{});
 }
 
 QSGNode *&DQMLGlobalObject::QSGNode_lastChild(QSGNode *node)
 {
-    return node->m_lastChild;
+    return D_PRIVATE_MEMBER(*node, QSGNode_m_lastChild_tag{});
 }
 
 QSGNode *&DQMLGlobalObject::QSGNode_parent(QSGNode *node)
 {
-    return node->m_parent;
+    return D_PRIVATE_MEMBER(*node, QSGNode_m_parent_tag{});
 }
 #endif
 

--- a/src/util/dprivateaccessor_p.h
+++ b/src/util/dprivateaccessor_p.h
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <QtCore/qcompilerdetection.h>
+
+// Private member accessor using the explicit template instantiation technique.
+//
+// C++ Standard [temp.explicit]/12 states:
+// "The usual access checking rules do not apply to names used to
+// specify explicit instantiation definitions."
+//
+// This allows passing pointers to private/protected data members and
+// member functions as template arguments in explicit instantiations,
+// bypassing normal access control — without modifying the class definition
+// and without the UB caused by "#define private public".
+//
+// NOTE: These helper structs must be in the SAME namespace as the Tag structs
+// (global namespace, since the macros expand at file scope). If they were in a
+// sub-namespace, the friend definition would create a different function than
+// the friend declaration in the Tag struct, causing undefined-reference errors.
+
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_GCC("-Wnon-template-friend")
+
+template<typename Tag>
+struct DtkDeclarativePrivateAccessor
+{
+    using MemberPtr = typename Tag::MemberPtr;
+    friend constexpr MemberPtr get(Tag) noexcept;
+};
+
+template<typename Tag, typename Tag::MemberPtr Ptr>
+struct DtkDeclarativePrivateAccessorImpl : DtkDeclarativePrivateAccessor<Tag>
+{
+    friend constexpr typename Tag::MemberPtr get(Tag) noexcept { return Ptr; }
+};
+
+QT_WARNING_POP
+
+#define D_DECLARE_PRIVATE_MEMBER(TagName, ClassName, Member, MemberType) \
+    struct TagName { \
+        using MemberPtr = MemberType ClassName::*; \
+        friend constexpr MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkDeclarativePrivateAccessorImpl<TagName, &ClassName::Member>
+
+#define D_DECLARE_PRIVATE_METHOD(TagName, ClassName, MethodName, RetType, ...) \
+    struct TagName { \
+        using MemberPtr = RetType (ClassName::*)(__VA_ARGS__); \
+        friend constexpr MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkDeclarativePrivateAccessorImpl<TagName, &ClassName::MethodName>
+
+#define D_DECLARE_PRIVATE_CONST_METHOD(TagName, ClassName, MethodName, RetType, ...) \
+    struct TagName { \
+        using MemberPtr = RetType (ClassName::*)(__VA_ARGS__) const; \
+        friend constexpr MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkDeclarativePrivateAccessorImpl<TagName, &ClassName::MethodName>
+
+#define D_DECLARE_PRIVATE_BITFIELD(TagName, ClassName, PrevMember, PrevMemberType, BfStorageType) \
+    struct TagName { \
+        using MemberPtr = PrevMemberType ClassName::*; \
+        friend constexpr MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkDeclarativePrivateAccessorImpl<TagName, &ClassName::PrevMember>; \
+    struct TagName##_bf_layout_mirror { PrevMemberType prev; BfStorageType storage; }; \
+    struct TagName##_Bits { \
+        static constexpr std::size_t kOffset = \
+            __builtin_offsetof(TagName##_bf_layout_mirror, storage) - \
+            __builtin_offsetof(TagName##_bf_layout_mirror, prev); \
+        static BfStorageType *storagePtr(ClassName *obj) noexcept { \
+            PrevMemberType &prev_ref = (*obj).*get(TagName{}); \
+            return reinterpret_cast<BfStorageType*>( \
+                reinterpret_cast<char *>(&prev_ref) + kOffset); \
+        } \
+        static const BfStorageType *storagePtr(const ClassName *obj) noexcept { \
+            return storagePtr(const_cast<ClassName *>(obj)); \
+        } \
+        static bool getBit(const ClassName *obj, unsigned bit) noexcept { \
+            return (*storagePtr(obj) >> bit) & BfStorageType{1}; \
+        } \
+        static void setBit(ClassName *obj, unsigned bit, bool val) noexcept { \
+            BfStorageType *p = storagePtr(obj); \
+            if (val) *p |= (BfStorageType{1} << bit); \
+            else     *p &= ~(BfStorageType{1} << bit); \
+        } \
+    }
+
+// Trampoline: ensures get(tag) is called from a context with no class-scope
+// get() member that might suppress ADL (C++ [basic.lookup.argdep] para 3).
+namespace dtk_private_detail {
+    template<typename Tag>
+    inline typename Tag::MemberPtr access(Tag t) noexcept { return get(t); }
+}
+
+#define D_PRIVATE_MEMBER(obj, tag) ((obj).*dtk_private_detail::access(tag))
+#define D_PRIVATE_CALL(obj, tag, ...) ((obj).*dtk_private_detail::access(tag))(__VA_ARGS__)
+#define D_PRIVATE_BF_GET(obj, TagName, bit_pos) \
+    TagName##_Bits::getBit(&(obj), (bit_pos))
+#define D_PRIVATE_BF_SET(obj, TagName, bit_pos, val) \
+    TagName##_Bits::setBit(&(obj), (bit_pos), (val))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,9 @@ find_package(Dtk${DTK_NAME_SUFFIX}Core REQUIRED)
 find_package(Dtk${DTK_NAME_SUFFIX}Gui REQUIRED)
 find_package(GTest REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Quick QuickControls2 Qml Test)
+if (NOT DTK5)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS QuickPrivate)
+endif()
 
 file(GLOB TEST_SOURCES
     ut_colorselector.cpp
@@ -69,6 +72,27 @@ target_link_libraries(${BIN_NAME} PRIVATE
     dl
     m
 )
+if (NOT DTK5)
+    target_link_libraries(${BIN_NAME} PRIVATE
+        Qt${QT_VERSION_MAJOR}::QuickPrivate
+    )
+
+    add_executable(test_qsgrenderer_accessor
+        ut_qsgrenderer_accessor.cpp
+    )
+    target_compile_options(test_qsgrenderer_accessor PRIVATE
+        "-fno-access-control"
+    )
+    target_link_libraries(test_qsgrenderer_accessor PRIVATE
+        Qt${QT_VERSION_MAJOR}::Test
+        Qt${QT_VERSION_MAJOR}::Quick
+        Qt${QT_VERSION_MAJOR}::QuickPrivate
+    )
+    add_test(NAME test_qsgrenderer_accessor COMMAND test_qsgrenderer_accessor)
+    set_property(TEST test_qsgrenderer_accessor PROPERTY
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+endif()
 
 set(APPLOADER_PLUGINDUMP_OUTPUT_DIR ${PROJECT_BINARY_DIR}/plugins)
 target_compile_definitions(${BIN_NAME} PRIVATE

--- a/tests/ut_qsgrenderer_accessor.cpp
+++ b/tests/ut_qsgrenderer_accessor.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <cstring>
+
+#include <QTest>
+#include <private/qsgrenderer_p.h>
+
+#include "../src/util/dprivateaccessor_p.h"
+
+D_DECLARE_PRIVATE_BITFIELD(Test_QSGRendererBFTag,
+                           QSGRenderer, m_nodes_dont_preprocess,
+                           QSet<QSGNode *>, uint);
+
+static constexpr unsigned kChangedEmittedBit = 0;
+static constexpr unsigned kIsRenderingBit = 1;
+
+static_assert(sizeof(QSGRenderer) == 432,
+              "QSGRenderer layout changed — update the accessor test");
+
+class ut_QSGRendererAccessor : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        std::memset(buffer, 0, sizeof(buffer));
+        renderer = reinterpret_cast<QSGRenderer *>(buffer);
+    }
+
+    void setIsRenderingVisibleViaDirectAccess()
+    {
+        D_PRIVATE_BF_SET(*renderer, Test_QSGRendererBFTag, kIsRenderingBit, true);
+
+        QCOMPARE(renderer->m_is_rendering, 1U);
+        QCOMPARE(renderer->m_changed_emitted, 0U);
+    }
+
+    void setChangedEmittedVisibleViaDirectAccess()
+    {
+        D_PRIVATE_BF_SET(*renderer, Test_QSGRendererBFTag, kChangedEmittedBit, true);
+
+        QCOMPARE(renderer->m_changed_emitted, 1U);
+        QCOMPARE(renderer->m_is_rendering, 0U);
+    }
+
+    void readIsRenderingViaAccessor()
+    {
+        renderer->m_is_rendering = true;
+
+        QVERIFY(D_PRIVATE_BF_GET(*renderer, Test_QSGRendererBFTag, kIsRenderingBit));
+        QVERIFY(!D_PRIVATE_BF_GET(*renderer, Test_QSGRendererBFTag, kChangedEmittedBit));
+    }
+
+    void readChangedEmittedViaAccessor()
+    {
+        renderer->m_changed_emitted = true;
+
+        QVERIFY(D_PRIVATE_BF_GET(*renderer, Test_QSGRendererBFTag, kChangedEmittedBit));
+        QVERIFY(!D_PRIVATE_BF_GET(*renderer, Test_QSGRendererBFTag, kIsRenderingBit));
+    }
+
+    void clearIsRenderingViaAccessor()
+    {
+        renderer->m_is_rendering = true;
+        renderer->m_changed_emitted = true;
+
+        D_PRIVATE_BF_SET(*renderer, Test_QSGRendererBFTag, kIsRenderingBit, false);
+
+        QCOMPARE(renderer->m_is_rendering, 0U);
+        QCOMPARE(renderer->m_changed_emitted, 1U);
+    }
+
+private:
+    alignas(QSGRenderer) unsigned char buffer[sizeof(QSGRenderer)];
+    QSGRenderer *renderer = nullptr;
+};
+
+QTEST_MAIN(ut_QSGRendererAccessor)
+
+#include "ut_qsgrenderer_accessor.moc"


### PR DESCRIPTION
Remove all '#define private/protected public' hacks and replace them with a proper C++ template-based private accessor pattern using explicit template instantiation (friend injection trick), mirroring the approach used in linuxdeepin/treeland#875.

Add src/private/dprivateaccessor_p.h with Accessor/AccessorImpl templates and D_DECLARE_PRIVATE_MEMBER, D_DECLARE_PRIVATE_METHOD, D_DECLARE_PRIVATE_CONST_METHOD, D_PRIVATE_MEMBER, D_PRIVATE_CALL macros. All helpers are in global namespace so ADL correctly finds the friend-injected get() function.