### PR TITLE
feat: add ComboBox blur preference

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -66,8 +66,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtk6declarative( =${binary:Version}),
  libdtk6core-dev,
- libdtk6gui-dev,
- libdtkcommon-dev,
+ libdtk6gui-dev (>> 6.7.42),
+ libdtkcommon-dev (>> 6.7.42),
  qt6-base-dev,
  qt6-declarative-dev
 Build-Profiles: <!nodtk6>
@@ -119,8 +119,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtkdeclarative5( =${binary:Version}),
  libdtkcore-dev,
- libdtkgui-dev,
- libdtkcommon-dev,
+ libdtkgui-dev (>> 5.7.42),
+ libdtkcommon-dev (>> 5.7.42),
  qtbase5-dev,
  qtdeclarative5-dev
 Build-Profiles: <!nodtk5>

--- a/qt6/src/qml/overridable/InWindowBlur.qml
+++ b/qt6/src/qml/overridable/InWindowBlur.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -18,7 +18,7 @@ Item {
     D.BackdropBlitter {
         id: blitter
         anchors.fill: parent
-        blitterEnabled: !D.DTK.isSoftwareRender
+        blitterEnabled: !D.DTK.isSoftwareRender && D.DTK.hasInWindowBlur
 
         MultiEffect {
             id: blur

--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -221,6 +221,11 @@ bool DQMLGlobalObject::hasAnimation()
     return DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::HasAnimations);
 }
 
+bool DQMLGlobalObject::hasInWindowBlur()
+{
+    return DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::HasInWindowBlur);
+}
+
 bool DQMLGlobalObject::isSoftwareRender()
 {
     static bool isSoftware = QQuickWindow::sceneGraphBackend() == QLatin1String("software");

--- a/src/private/dqmlglobalobject_p.h
+++ b/src/private/dqmlglobalobject_p.h
@@ -120,6 +120,7 @@ class DQMLGlobalObject : public QObject, public DTK_CORE_NAMESPACE::DObject
     Q_PROPERTY(bool hasComposite READ hasComposite NOTIFY hasCompositeChanged)
     Q_PROPERTY(bool hasNoTitlebar READ hasNoTitlebar NOTIFY hasNoTitlebarChanged)
     Q_PROPERTY(bool hasAnimation READ hasAnimation NOTIFY hasAnimationChanged)
+    Q_PROPERTY(bool hasInWindowBlur READ hasInWindowBlur NOTIFY hasInWindowBlurChanged)
     Q_PROPERTY(bool isSoftwareRender READ isSoftwareRender FINAL CONSTANT)
     Q_PROPERTY(DTK_GUI_NAMESPACE::DWindowManagerHelper::WMName windowManagerName READ windowManagerName CONSTANT)
     Q_PROPERTY(DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType themeType READ themeType NOTIFY themeTypeChanged)
@@ -185,6 +186,7 @@ public:
     bool hasComposite() const;
     bool hasNoTitlebar() const;
     static bool hasAnimation();
+    static bool hasInWindowBlur();
     static bool isSoftwareRender();
 
     DWindowManagerHelper::WMName windowManagerName() const;
@@ -252,6 +254,7 @@ Q_SIGNALS:
     void hasCompositeChanged();
     void hasNoTitlebarChanged();
     void hasAnimationChanged();
+    void hasInWindowBlurChanged();
     void paletteChanged();
     void inactivePaletteChanged();
     void themeTypeChanged(DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType themeType);


### PR DESCRIPTION
1. Add a DTK configuration binding in ComboBox.qml using org.deepin.dtk.preference
2. Introduce the enableComboBoxBlur boolean preference with a default value of true
3. Bind the popup menu's enableBlur property to the new configuration so the ComboBox dropdown blur effect can be turned on or off dynamically
4. This change makes the dropdown visual effect configurable, allowing environments or users with different performance or visual preference requirements to control blur behavior without modifying component logic

Log: Added a configurable blur effect option for ComboBox dropdowns

Influence:
1. Verify that ComboBox dropdowns still display blur by default when no custom preference is set
2. Disable enableComboBoxBlur in org.deepin.dtk.preference and confirm the dropdown background renders without blur
3. Re-enable the preference and confirm the blur effect is restored immediately or after expected configuration reload timing
4. Test multiple ComboBox instances to ensure the configuration is applied consistently across all dropdown menus
5. Verify no regression in dropdown rendering, sizing, radius, background color, and open/close interaction
6. Check behavior on low-performance or blur-unsupported environments to confirm the dropdown degrades gracefully

feat: 新增 ComboBox 模糊效果配置

1. 在 ComboBox.qml 中新增 DTK 配置绑定，使用 org.deepin.dtk.preference 配置项
2. 引入 enableComboBoxBlur 布尔配置项，默认值为 true
3. 将下拉弹出菜单的 enableBlur 属性绑定到该配置，使 ComboBox 下拉框模糊 效果可以动态开启或关闭
4. 该变更将下拉视觉效果改为可配置项，便于在不同性能环境或不同用户视觉偏 好下控制模糊行为，而无需修改组件本身逻辑

Log: 为 ComboBox 下拉框新增可配置的模糊效果选项

Influence:
1. 验证在未设置自定义偏好时，ComboBox 下拉框默认仍会显示模糊效果
2. 在 org.deepin.dtk.preference 中关闭 enableComboBoxBlur，确认下拉框背 景渲染为无模糊效果
3. 重新开启该配置，确认模糊效果可立即恢复或按预期的配置刷新时机恢复
4. 测试多个 ComboBox 实例，确保所有下拉菜单都能一致应用该配置
5. 验证下拉框渲染、尺寸、圆角、背景色以及展开/收起交互没有回归
6. 检查在低性能环境或不支持模糊的环境下的表现，确认下拉框能够平滑降级

PMS: BUG-358837
Change-Id: Ifd7255009fa87539481ebb515f93f89ac5958ce5