### PR TITLE
feat: add hasInWindowBlur property to DQMLGlobalObject

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -66,8 +66,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtk6declarative( =${binary:Version}),
  libdtk6core-dev,
- libdtk6gui-dev,
- libdtkcommon-dev,
+ libdtk6gui-dev (>> 6.7.42),
+ libdtkcommon-dev (>> 6.7.42),
  qt6-base-dev,
  qt6-declarative-dev
 Build-Profiles: <!nodtk6>
@@ -119,8 +119,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtkdeclarative5( =${binary:Version}),
  libdtkcore-dev,
- libdtkgui-dev,
- libdtkcommon-dev,
+ libdtkgui-dev (>> 5.7.42),
+ libdtkcommon-dev (>> 5.7.42),
  qtbase5-dev,
  qtdeclarative5-dev
 Build-Profiles: <!nodtk5>

--- a/qt6/src/qml/overridable/InWindowBlur.qml
+++ b/qt6/src/qml/overridable/InWindowBlur.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -18,7 +18,7 @@ Item {
     D.BackdropBlitter {
         id: blitter
         anchors.fill: parent
-        blitterEnabled: !D.DTK.isSoftwareRender
+        blitterEnabled: !D.DTK.isSoftwareRender && D.DTK.hasInWindowBlur
 
         MultiEffect {
             id: blur

--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -221,6 +221,11 @@ bool DQMLGlobalObject::hasAnimation()
     return DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::HasAnimations);
 }
 
+bool DQMLGlobalObject::hasInWindowBlur()
+{
+    return DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::HasInWindowBlur);
+}
+
 bool DQMLGlobalObject::isSoftwareRender()
 {
     static bool isSoftware = QQuickWindow::sceneGraphBackend() == QLatin1String("software");

--- a/src/private/dqmlglobalobject_p.h
+++ b/src/private/dqmlglobalobject_p.h
@@ -120,6 +120,7 @@ class DQMLGlobalObject : public QObject, public DTK_CORE_NAMESPACE::DObject
     Q_PROPERTY(bool hasComposite READ hasComposite NOTIFY hasCompositeChanged)
     Q_PROPERTY(bool hasNoTitlebar READ hasNoTitlebar NOTIFY hasNoTitlebarChanged)
     Q_PROPERTY(bool hasAnimation READ hasAnimation NOTIFY hasAnimationChanged)
+    Q_PROPERTY(bool hasInWindowBlur READ hasInWindowBlur NOTIFY hasInWindowBlurChanged)
     Q_PROPERTY(bool isSoftwareRender READ isSoftwareRender FINAL CONSTANT)
     Q_PROPERTY(DTK_GUI_NAMESPACE::DWindowManagerHelper::WMName windowManagerName READ windowManagerName CONSTANT)
     Q_PROPERTY(DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType themeType READ themeType NOTIFY themeTypeChanged)
@@ -185,6 +186,7 @@ public:
     bool hasComposite() const;
     bool hasNoTitlebar() const;
     static bool hasAnimation();
+    static bool hasInWindowBlur();
     static bool isSoftwareRender();
 
     DWindowManagerHelper::WMName windowManagerName() const;
@@ -252,6 +254,7 @@ Q_SIGNALS:
     void hasCompositeChanged();
     void hasNoTitlebarChanged();
     void hasAnimationChanged();
+    void hasInWindowBlurChanged();
     void paletteChanged();
     void inactivePaletteChanged();
     void themeTypeChanged(DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType themeType);


### PR DESCRIPTION
## Summary

- Add `hasInWindowBlur` property to `DQMLGlobalObject` QML singleton
- InWindowBlur QML component checks `D.DTK.hasInWindowBlur` before enabling blur
- Add version dependencies for dtkgui and dtkcommon in debian/control

## Issue

https://pms.uniontech.com/task-view-390117.html

## Dependencies

- dtkgui: `HasInWindowBlur` attribute (>> 6.7.42 / >> 5.7.42)
- dtkcommon: `disableInWindowBlur` config key (>> 6.7.42 / >> 5.7.42)

## Test Plan

- [ ] Test hasInWindowBlur property returns correct value
- [ ] Test InWindowBlur component disables blur when hasInWindowBlur is false