### PR TITLE
fix(dialog): remove KWin blur from DialogWindow to fix dark theme issue

### DIFF
--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -19,10 +19,9 @@ Window {
     D.DWindow.enableSystemResize: false
     D.DWindow.motifFunctions: D.WindowManagerHelper.FUNC_ALL & ~D.WindowManagerHelper.FUNC_RESIZE
     D.DWindow.wmWindowTypes: D.WindowManagerHelper.DialogType
-    D.DWindow.enableBlurWindow: true
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint
     D.ColorSelector.family: D.Palette.CrystalColor
-    color: D.DWindow.enableBlurWindow ? "transparent" : (active ? D.DTK.palette.window : D.DTK.inactivePalette.window)
+    color: "transparent"
     height: content.height
     width: content.width
 


### PR DESCRIPTION
## 问题

DialogWindow 默认启用 KWin blur (`enableBlurWindow: true`)。当应用强制深色主题时（如 dde-launchpad 全屏模式），blur 会透过对话框显示背后的深色背景，导致对话框在浅色系统主题下也显示为深色。

## 修复

- 移除 `enableBlurWindow: true` 默认值
- 将 `color` 直接设为 `transparent`，不再依赖 `enableBlurWindow` 条件判断

## 影响

所有使用 DialogWindow 的对话框将不再启用 KWin blur，使用标准 DTK 调色板。

## 测试

已在调试机上验证，dde-launchpad 卸载确认对话框恢复正常。

Bug: https://pms.uniontech.com/bug-view-359629.html

## Summary by Sourcery

Bug Fixes:
- Fix DialogWindow appearing dark under light system themes when applications enforce dark mode by disabling KWin blur and always using a transparent window color.