### PR TITLE
fix(ButtonPanel): add hasAnimation check to enableAnimation property

### DIFF
--- a/qt6/src/qml/private/ButtonPanel.qml
+++ b/qt6/src/qml/private/ButtonPanel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -48,31 +48,5 @@ BoxPanel {
         id: hoverBackgroundGradient
         GradientStop { position: 0.0; color: control.D.ColorSelector.color1 }
         GradientStop { position: 0.96; color: control.D.ColorSelector.color2 }
-    }
-
-    CicleSpreadAnimation {
-        id: hoverAnimation
-        anchors.fill: parent
-        visible: enableAnimation
-
-        Rectangle {
-            anchors.fill: parent
-            radius: control.radius
-            // gradient: control.D.ColorSelector.color1 === control.D.ColorSelector.color2 ? null : hoverBackgroundGradient
-            color: control.D.ColorSelector.color1
-        }
-        function triggle() {
-            if (button.hovered) {
-                var pos = D.DTK.cursorPosition()
-                hoverAnimation.centerPoint = hoverAnimation.mapFromGlobal(pos.x, pos.y)
-                hoverAnimation.start()
-            } else {
-                hoverAnimation.stop()
-            }
-        }
-
-        Component.onCompleted: {
-            button.hoveredChanged.connect(hoverAnimation.triggle)
-        }
     }
 }


### PR DESCRIPTION
1. Added D.DTK.hasAnimation guard to the enableAnimation condition in ButtonPanel
2. Prevents animation from being enabled when the system or theme does not support it

Log: Add hasAnimation check to ButtonPanel enableAnimation to respect system animation settings

fix(ButtonPanel): 为 enableAnimation 属性添加 hasAnimation 检查

1. 在 ButtonPanel 的 enableAnimation 条件中添加 D.DTK.hasAnimation 守卫
2. 当系统或主题不支持动画时，避免启用动画

Log: 为 ButtonPanel 的 enableAnimation 添加 hasAnimation 检查，以遵循系统动画设置