### PR TITLE
ci: split Qt5 and Qt6 workflow steps

### DIFF
--- a/.github/workflows/dtkdeclarative-archlinux-build.yml
+++ b/.github/workflows/dtkdeclarative-archlinux-build.yml
@@ -60,13 +60,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build and install latest DTK dependencies from source
+      - name: Build and install latest DTK Qt5 dependencies from source
+        if: matrix.qt_version == 5
         run: |
           set -euxo pipefail
 
           build_repo() {
             local repo="$1"
-            local extra_args="${2:-}"
+            shift
             case "${repo}" in
               dtkcommon|dtklog|dtkcore|dtkgui) ;;
               *) echo "unsupported repo: ${repo}" >&2; exit 1 ;;
@@ -81,17 +82,49 @@ jobs:
               -DBUILD_DOCS=OFF \
               -DBUILD_EXAMPLES=OFF \
               -DBUILD_TESTING=OFF \
-              ${extra_args}
+              "$@"
             cmake --build "${repo}/build" -j"$(nproc)"
             cmake --install "${repo}/build"
           }
 
           build_repo dtkcommon
-          build_repo dtklog "-DDTK5=${{ matrix.dtk5 }}"
-          build_repo dtkcore "-DDTK5=${{ matrix.dtk5 }}"
-          build_repo dtkgui "-DDTK5=${{ matrix.dtk5 }}"
+          build_repo dtklog -DDTK5=ON
+          build_repo dtkcore -DDTK5=ON
+          build_repo dtkgui -DDTK5=ON
 
-      - name: Configure dtkdeclarative
+      - name: Build and install latest DTK Qt6 dependencies from source
+        if: matrix.qt_version == 6
+        run: |
+          set -euxo pipefail
+
+          build_repo() {
+            local repo="$1"
+            shift
+            case "${repo}" in
+              dtkcommon|dtklog|dtkcore|dtkgui) ;;
+              *) echo "unsupported repo: ${repo}" >&2; exit 1 ;;
+            esac
+            cd /tmp
+            rm -rf "${repo}"
+            git clone --depth=1 "https://github.com/linuxdeepin/${repo}.git"
+            cmake -S "${repo}" -B "${repo}/build" \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=/usr \
+              -DBUILD_DOCS=OFF \
+              -DBUILD_EXAMPLES=OFF \
+              -DBUILD_TESTING=OFF \
+              "$@"
+            cmake --build "${repo}/build" -j"$(nproc)"
+            cmake --install "${repo}/build"
+          }
+
+          build_repo dtkcommon
+          build_repo dtklog -DDTK5=OFF
+          build_repo dtkcore -DDTK5=OFF
+          build_repo dtkgui -DDTK5=OFF
+
+      - name: Configure dtkdeclarative for Qt${{ matrix.qt_version }}
         run: |
           set -o pipefail
           cmake -B build \
@@ -116,7 +149,7 @@ jobs:
             echo "::error::$line"
           done
 
-      - name: Build dtkdeclarative
+      - name: Build dtkdeclarative for Qt${{ matrix.qt_version }}
         run: |
           set -o pipefail
           cmake --build build -j$(nproc) 2>&1 | tee /tmp/cmake-build.log
@@ -149,7 +182,7 @@ jobs:
             echo "::error::$line"
           done
 
-      - name: Install dtkdeclarative to staging directory
+      - name: Install dtkdeclarative Qt${{ matrix.qt_version }} to staging directory
         run: |
           DESTDIR=/tmp/dtkdeclarative-install cmake --install build
           echo "Total: $(find /tmp/dtkdeclarative-install -type f | wc -l) files"

--- a/.github/workflows/dtkdeclarative-deepin-build.yml
+++ b/.github/workflows/dtkdeclarative-deepin-build.yml
@@ -39,7 +39,7 @@ jobs:
           dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
           echo "✅ dtkcommon installed"
 
-      - name: Build and install dtklog from source
+      - name: Build and install dtklog from source for Qt${{ matrix.qt_version }}
         run: |
           set -euxo pipefail
           cd /tmp
@@ -50,7 +50,7 @@ jobs:
           dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
           echo "✅ dtklog installed"
 
-      - name: Build and install treeland-protocols from source
+      - name: Build and install treeland-protocols from source for Qt${{ matrix.qt_version }}
         run: |
           set -euxo pipefail
           apt-get install -y --allow-unauthenticated wlr-protocols || true
@@ -62,7 +62,7 @@ jobs:
           dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
           echo "✅ treeland-protocols installed"
 
-      - name: Build and install dtkcore from source
+      - name: Build and install dtkcore from source for Qt${{ matrix.qt_version }}
         run: |
           set -euxo pipefail
           cd /tmp
@@ -73,7 +73,7 @@ jobs:
           dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
           echo "✅ dtkcore installed"
 
-      - name: Build and install dtkgui from source
+      - name: Build and install dtkgui from source for Qt${{ matrix.qt_version }}
         run: |
           set -euxo pipefail
           cd /tmp
@@ -84,12 +84,12 @@ jobs:
           dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
           echo "✅ dtkgui installed"
 
-      - name: Install dtkdeclarative build dependencies
+      - name: Install dtkdeclarative Qt${{ matrix.qt_version }} build dependencies
         run: |
           set -euxo pipefail
           mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
 
-      - name: Enable unit tests in deb build
+      - name: Enable unit tests in Qt${{ matrix.qt_version }} deb build
         if: matrix.dtk_profile == 'nodtk6'
         run: |
           set -euxo pipefail
@@ -97,7 +97,7 @@ jobs:
             sed -i 's/BUILD_TESTING=OFF/BUILD_TESTING=ON/g' debian/rules
           fi
 
-      - name: Build dtkdeclarative deb packages
+      - name: Build dtkdeclarative Qt${{ matrix.qt_version }} deb packages
         run: |
           set -euxo pipefail
           export QT_QPA_PLATFORM=offscreen


### PR DESCRIPTION
## Summary\n- split Arch Linux workflow source-build steps by Qt5/Qt6 like dtkcore#564\n- add Qt-version-specific step names in Deepin workflow to make the matrix intent explicit\n- keep the existing test behavior so the workflow remains green\n