### PR TITLE
fix(popup): improve popup background with blur and palette

### DIFF
--- a/qt6/src/qml/Popup.qml
+++ b/qt6/src/qml/Popup.qml
@@ -11,6 +11,8 @@ import org.deepin.dtk.style 1.0 as DS
 T.Popup {
     id: control
 
+    palette: D.DTK.palette
+
     property bool closeOnInactive: true
     readonly property bool active: parent && parent.Window.active
     implicitWidth: DS.Style.control.implicitWidth(control)
@@ -18,12 +20,24 @@ T.Popup {
 
     padding: DS.Style.popup.padding
 
-    background: Loader {
-        active: control.popupType !== Popup.Window
-        sourceComponent: FloatingPanel {
-            implicitHeight: DS.Style.popup.height
-            implicitWidth: DS.Style.popup.width
-            radius: DS.Style.popup.radius
+    background: Item {
+        implicitWidth: DS.Style.control.implicitWidth(control)
+        implicitHeight: DS.Style.control.implicitHeight(control)
+
+        Loader {
+            anchors.fill: parent
+            active: control.popupType === Popup.Window
+            sourceComponent: D.StyledBehindWindowBlur { }
+        }
+
+        Loader {
+            anchors.fill: parent
+            active: control.popupType !== Popup.Window
+            sourceComponent: FloatingPanel {
+                implicitHeight: DS.Style.popup.height
+                implicitWidth: DS.Style.popup.width
+                radius: DS.Style.popup.radius
+            }
         }
     }
 


### PR DESCRIPTION
1. Add DTK palette binding for proper color integration
2. Split background into two Loaders for different popup types
3. Use StyledBehindWindowBlur for Popup.Window type
4. Retain FloatingPanel for non-window popup types

Log: Enhance Popup to support window blur and DTK palette

fix(popup): 改进弹出窗口背景模糊和调色板

1. 添加 DTK 调色板绑定以实现正确的颜色集成
2. 将背景拆分为两个加载器以适配不同的弹出窗口类型
3. 为 Popup.Window 类型使用 StyledBehindWindowBlur 模糊效果
4. 非窗口类型弹出窗口继续使用 FloatingPanel

Log: 增强 Popup 组件，支持窗口模糊效果和 DTK 调色板