### PR TITLE
fix: set title font to t6 specification

### DIFF
--- a/qt6/src/qml/DialogWindow.qml
+++ b/qt6/src/qml/DialogWindow.qml
@@ -74,6 +74,7 @@ Window {
                         text: control.title
                         elide: Text.ElideRight
                         horizontalAlignment: Text.AlignHCenter
+                        font: D.DTK.fontManager.t6
                     }
                 }
             }


### PR DESCRIPTION
1. Add font property to DialogWindow title label using D.DTK.fontManager.t6 to dynamically adapt the title to the current system font size

Log: Set DialogWindow title font to t6 for dynamic system font size adaptation

fix: 设置标题字体为 t6 规范

1. 为 DialogWindow 标题标签添加 D.DTK.fontManager.t6 字体属性， 使标题实时适配当前系统字号大小

Log: 设置 DialogWindow 标题字体为 t6 以实时适配系统字号大小
PMS: BUG-363185