### PR TITLE
fix(window-button): load icon synchronously

### DIFF
--- a/qt6/src/qml/WindowButton.qml
+++ b/qt6/src/qml/WindowButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,14 @@ D.IconButton {
     bottomPadding: 0
     leftPadding: 0
     rightPadding: 0
+    contentItem: D.DciIcon {
+        name: control.icon.name
+        asynchronous: false
+        palette: D.DTK.makeIconPalette(control.palette)
+        mode: control.D.ColorSelector.controlState
+        theme: control.D.ColorSelector.controlTheme
+        sourceSize: Qt.size(control.icon.width, control.icon.height)
+    }
     icon {
         width: DS.Style.windowButton.width
         height: DS.Style.windowButton.height


### PR DESCRIPTION
1. Override the window button content item with a DCI icon.
2. Disable asynchronous loading for the icon to avoid a blank first frame.
3. Keep the existing palette, state, theme, and source size bindings.

Log: Load window button icons synchronously to prevent startup flicker.

fix(window-button): 同步加载窗口按钮图标

1. 使用 DCI 图标覆盖窗口按钮的内容项。
2. 关闭图标异步加载，避免启动首帧空白。
3. 保留原有调色板、状态、主题和源尺寸绑定。

Log: 同步加载窗口按钮图标，避免启动时图标闪烁。
PMS: TASK-390989

## Summary by Sourcery

Bug Fixes:
- Prevent startup flicker by disabling asynchronous loading for the window button icon and binding a synchronous DCI icon as the button content.