### PR TITLE
fix: prevent null pointer dereference by disconnecting textureChanged signal

### DIFF
--- a/src/dquickitemviewport.cpp
+++ b/src/dquickitemviewport.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -132,6 +132,13 @@ void DQuickItemViewportPrivate::clearPreprocessNode(PreprocessNode *oldNode)
 {
     Q_ASSERT(load(preprocessNode) == oldNode);
     preprocessNode = nullptr;
+
+    // 断开 textureChanged 信号连接，避免在场景图清理过程中
+    // 信号触发时访问已清除的 preprocessNode 导致空指针解引用
+    if (textureChangedConnection) {
+        QObject::disconnect(textureChangedConnection);
+        textureChangedConnection = {};
+    }
 }
 
 void DQuickItemViewportPrivate::updateUsePreprocess() const


### PR DESCRIPTION
1. The crash occurred during scene graph cleanup when the textureChanged
signal
   was triggered after preprocessNode had already been cleared
2. Added explicit disconnection of textureChanged signal connection in
   clearPreprocessNode to prevent accessing freed preprocessNode
3. This ensures the signal handler doesn't execute after node cleanup

Influence:
1. Test scene graph cleanup by closing/quitting the application
2. Verify no crashes occur when transitioning between different viewport
states
3. Test viewport rendering with dynamic content updates
4. Validate no memory leaks from dangling signal connections

fix: 通过断开textureChanged信号连接防止空指针解引用

1. 崩溃发生在场景图清理过程中，textureChanged信号在preprocessNode被清除
后触发
2. 在clearPreprocessNode中添加显式的信号连接断开操作，防止访问已释放
的preprocessNode
3. 确保信号处理函数在节点清理后不会执行

Influence:
1. 通过关闭/退出应用测试场景图清理过程
2. 验证在不同视口状态切换时不会发生崩溃
3. 测试带动态内容更新的视口渲染
4. 验证没有因悬空信号连接导致的内存泄漏
