### PR TITLE
fix(popup): focus window popups for input

### DIFF
--- a/qt6/src/qml/Popup.qml
+++ b/qt6/src/qml/Popup.qml
@@ -12,6 +12,7 @@ T.Popup {
     id: control
 
     palette: D.DTK.palette
+    focus: popupType === Popup.Window
 
     property bool closeOnInactive: true
     readonly property bool active: parent && parent.Window.active

--- a/src/private/dpopupwindowhandle.cpp
+++ b/src/private/dpopupwindowhandle.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 
 #include <private/qquickitem_p.h>
+#include <qpa/qwindowsysteminterface.h>
 
 DQUICK_BEGIN_NAMESPACE
 
@@ -52,6 +53,7 @@ DPopupWindowHandle::DPopupWindowHandle(QObject *popup)
     popupItemReparented();
 
     connect(popup, SIGNAL(popupTypeChanged()), this, SLOT(updateEnabled()));
+    connect(popup, SIGNAL(visibleChanged()), this, SLOT(onPopupVisibleChanged()));
 }
 
 DQuickWindowAttached *DPopupWindowHandle::qmlAttachedProperties(QObject *object)
@@ -124,6 +126,9 @@ bool DPopupWindowHandle::isEnabled() const
 
 void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
 {
+    if (!window)
+        restoreParentFocus();
+
     // Cleanup old filters
     if (m_popupWin) {
         m_popupWin->removeEventFilter(this);
@@ -154,10 +159,22 @@ void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
     }
 }
 
+void DPopupWindowHandle::onPopupVisibleChanged()
+{
+    if (!m_popup || m_popup->property("visible").toBool())
+        return;
+
+    restoreParentFocus();
+}
+
 bool DPopupWindowHandle::eventFilter(QObject *watched, QEvent *event)
 {
     if (watched == m_popupWin && event->type() == QEvent::Move) {
         adjustPopupPosition();
+    }
+
+    if (watched == m_popupWin && event->type() == QEvent::Show) {
+        requestPopupFocus();
     }
 
     // Close popup on parent window click (only while popup is visible)
@@ -280,7 +297,52 @@ void DPopupWindowHandle::adjustPopupPosition()
         m_popupWin->setPosition(newPos);
 }
 
+void DPopupWindowHandle::requestPopupFocus()
+{
+    if (!m_popup || !isEnabled() || !m_popupWin || !m_popupWin->isVisible())
+        return;
+    if (!m_popup->property("focus").toBool())
+        return;
+
+    m_restoreFocusItem = m_parentWindow ? m_parentWindow->activeFocusItem() : nullptr;
+
+    QMetaObject::invokeMethod(this, [this] {
+        if (!isEnabled() || !m_popup->property("focus").toBool() || !m_popupWin || !m_popupWin->isVisible())
+            return;
+
+        QPointer<QQuickItem> item = popupItem();
+        if (!item || item->window() != m_popupWin)
+            return;
+
+        m_popupFocusRequested = true;
+        m_popupWin->requestActivate();
+    }, Qt::QueuedConnection);
+}
+
+void DPopupWindowHandle::restoreParentFocus()
+{
+    if (!m_popupFocusRequested)
+        return;
+
+    m_popupFocusRequested = false;
+
+    if (!m_popupWin || !m_parentWindow || !m_parentWindow->isVisible()) {
+        m_restoreFocusItem.clear();
+        return;
+    }
+
+    m_parentWindow->requestActivate();
+    if (QGuiApplication::focusWindow() == m_popupWin)
+        QWindowSystemInterface::handleFocusWindowChanged(m_parentWindow, Qt::PopupFocusReason);
+
+    if (m_restoreFocusItem && m_restoreFocusItem->window() == m_parentWindow
+            && m_restoreFocusItem->isVisible() && m_restoreFocusItem->isEnabled()) {
+        m_restoreFocusItem->forceActiveFocus(Qt::OtherFocusReason);
+    }
+
+    m_restoreFocusItem.clear();
+}
+
 DQUICK_END_NAMESPACE
 
 #include "moc_dpopupwindowhandle_p.cpp"
-

--- a/src/private/dpopupwindowhandle_p.h
+++ b/src/private/dpopupwindowhandle_p.h
@@ -51,6 +51,7 @@ protected:
 private Q_SLOTS:
     void updateEnabled();
     void onWindowChanged(QQuickWindow *window);
+    void onPopupVisibleChanged();
 
 private:
     QQuickWindow *popupWindow() const;
@@ -59,6 +60,8 @@ private:
 
     bool isEnabled() const;
     void adjustPopupPosition();
+    void requestPopupFocus();
+    void restoreParentFocus();
     
 private:
     QObject *m_popup = nullptr;
@@ -68,6 +71,8 @@ private:
     QPointer<QQuickWindow> m_parentWindow = nullptr;
     QPointer<QQuickWindow> m_popupWin = nullptr;
     QPointer<QQuickItem> m_trackedItem = nullptr;
+    QPointer<QQuickItem> m_restoreFocusItem = nullptr;
+    bool m_popupFocusRequested = false;
 };
 
 DQUICK_END_NAMESPACE


### PR DESCRIPTION
1. Enable focus for popups using window mode.
2. Request activation when the popup window is shown.
3. Ensure input controls inside popup windows can trigger the input method.

Log: Focus window popups on show so embedded input controls can open the input method.

fix(popup): 让窗口弹窗支持输入法

1. 为窗口模式的弹窗启用焦点。
2. 在弹窗窗口显示时请求激活。
3. 确保窗口弹窗内的输入控件可以调起输入法。

Log: 显示窗口弹窗时获取焦点，使内部输入控件可以调起输入法。

## Summary by Sourcery

Ensure window-based popups gain focus and activation when shown so embedded input controls can properly receive input and trigger the input method.

Bug Fixes:
- Request focus and window activation for visible window-mode popups on show to restore input method behavior for embedded input controls.

Enhancements:
- Set QML window-mode popups to be focusable by default to align popup focus behavior with input expectations.