### PR TITLE
fix(settings): clip overflow text in basic settings

### DIFF
--- a/qt6/src/qml/settings/SettingsDialog.qml
+++ b/qt6/src/qml/settings/SettingsDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -30,6 +30,7 @@ DialogWindow {
 
     ScrollView {
         id: navigationBg
+        clip: true
         width: DS.Style.settings.navigation.width
         background: Rectangle {
             anchors.fill: parent
@@ -50,6 +51,7 @@ DialogWindow {
 
     ScrollView {
         id: contentBg
+        clip: true
         anchors {
             right: parent.right
             left: navigationBg.right


### PR DESCRIPTION
1. Add clip property to navigation ScrollView to prevent text overflow
2. Add clip property to content ScrollView to prevent text overflow

Log: Fix text display overflow in application settings basic settings page

fix(settings): 修复基础设置中文案显示超出范围

1. 为导航区域 ScrollView 添加 clip 属性防止文案溢出
2. 为内容区域 ScrollView 添加 clip 属性防止文案溢出

Log: 修复应用设置基础设置页面文案显示超出范围
PMS: BUG-366511