### PR TITLE
fix: skip popup position clamping on Wayland

### DIFF
--- a/src/private/dpopupwindowhandle.cpp
+++ b/src/private/dpopupwindowhandle.cpp
@@ -206,6 +206,9 @@ void DPopupWindowHandle::adjustPopupPosition()
     if (!isEnabled() ||!m_popupWin)
         return;
 
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform))
+        return;
+
     const QSize size = m_popupWin->size();
     if (size.width() <= 0 || size.height() <= 0)
         return;
@@ -235,7 +238,7 @@ void DPopupWindowHandle::adjustPopupPosition()
     if (!screen)
         return;
 
-    const QRectF bounds(screen->availableGeometry());
+    const QRectF bounds(screen->geometry());
     QRectF rect(QPointF(m_popupWin->position()), QSizeF(size));
 
     // Horizontal flip for submenus:


### PR DESCRIPTION
## Summary
- Skip global screen-bound popup clamping on Wayland.
- Preserve Qt/Wayland popup placement relative to the parent surface.
- Keep the existing X11 position adjustment unchanged.

## Test plan
- Tested with dde-shell dock context menu on Wayland/Treeland with popup blur enabled.
- Confirmed the menu opens at the expected pointer position.

Pms: BUG-295233