### PR TITLE
fix: prevent icon size flickering when DPR changes with empty sourceSize

### DIFF
--- a/src/private/dquickiconimage.cpp
+++ b/src/private/dquickiconimage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -352,7 +352,12 @@ void DQuickIconImage::itemChange(ItemChange change, const ItemChangeData &value)
     Q_D(DQuickIconImage);
 
     switch (change) {
-    case ItemDevicePixelRatioHasChanged: Q_FALLTHROUGH();
+    case ItemDevicePixelRatioHasChanged: {
+        if (d->updateDevicePixelRatio(1.0)) {
+            d->maybeUpdateUrl();
+        }
+    }
+        break;
     case ItemEnabledHasChanged: {
         // ###!(Chen Bin): When the program exits, it will be called
         // again, but the engine has been freed, causing subsequent


### PR DESCRIPTION
1. Fixed an issue where icon size flickering occurred under fractional
scaling on Wayland, caused by Qt resetting devicePixelRatio without
calling updateDevicePixelRatio when sourceSize is empty
2. Added condition to call maybeUpdateUrl only when device pixel ratio
actually changes in itemChange, ensuring consistent icon rendering

Log: Fixed icon flickering issue under Wayland fractional scaling when
sourceSize is empty

Influence:
1. Test icon rendering under Wayland with fractional scaling (e.g.,
125%, 150%)
2. Verify no flickering when window moves between monitors with
different DPIs
3. Check icon display when sourceSize is explicitly set
4. Test with empty sourceSize to ensure stable behavior
5. Verify on non-Wayland platforms to maintain existing functionality

fix: 修复空sourceSize时DPR变化导致图标大小闪烁问题

1. 修复了Wayland下分数缩放时，当sourceSize为空，Qt重置devicePixelRatio但
未调用updateDevicePixelRatio导致的图标大小闪烁问题
2. 在itemChange中添加条件判断，仅在设备像素比实际发生变化时才调用
maybeUpdateUrl，确保图标渲染一致性

Log: 修复Wayland分数缩放下图标闪烁问题

Influence:
1. 在Wayland环境下测试分数缩放（如125%、150%）时的图标渲染
2. 验证窗口在不同DPI显示器间移动时无闪烁
3. 检查显式设置sourceSize时的图标显示
4. 测试空sourceSize情况以确保行为稳定
5. 在非Wayland平台上验证以保持现有功能正常

PMS: BUG-366597

## Summary by Sourcery

Prevent icon flickering caused by unnecessary icon URL updates when the device pixel ratio changes, particularly under Wayland fractional scaling with empty sourceSize.

Bug Fixes:
- Avoid triggering icon URL updates unless the device pixel ratio actually changes to prevent icon size flickering under fractional scaling scenarios.

Chores:
- Update the SPDX copyright years for dquickiconimage.cpp to include 2026.