### PR TITLE
chore: update cmake minimum required version in template

### DIFF
--- a/misc/qml-app-template/src/main/CMakeLists.txt
+++ b/misc/qml-app-template/src/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 
 set(APP_BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/bin/)
 set(APP_NAME ${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
更新 qml-app-template 中 CMakeLists.txt 要求的 CMake 版本，避免过低导致警告

Log:

## Summary by Sourcery

Build:
- Increase the cmake_minimum_required version in the qml-app-template CMakeLists.txt from 3.1 to 3.16.