### PR TITLE
fix: add blur radius limit to prevent shadow crash

### DIFF
--- a/src/private/dquickimageprovider.cpp
+++ b/src/private/dquickimageprovider.cpp
@@ -597,7 +597,7 @@ static inline void imageConvoluteFilter(const uint8_t *startRow, uint8_t *destin
 
 static inline void doBoxShdowBlur(QImage &image, int radius, const QRect &rect = QRect())
 {
-    if (radius < 2) {
+    if (radius < 2 || radius > 100) {
         return;
     }
 
@@ -667,6 +667,11 @@ static void cleanFunction(void *image) { delete static_cast<QImage*>(image); }
 ShadowImage *DQuickShadowProvider::getRawShadow(const ShadowConfig &config)
 {
     if (Q_UNLIKELY(qIsNull(config.blurRadius))) {
+        return nullptr;
+    }
+
+    // 限制 blurRadius 在合理范围内，防止异常值导致内存崩溃
+    if (Q_UNLIKELY(config.blurRadius < 0 || config.blurRadius > 100)) {
         return nullptr;
     }
 


### PR DESCRIPTION
1. Add blur radius validation in doBoxShdowBlur to return early when
radius exceeds 100
2. Add blur radius pre-check in getRawShadow to reject invalid values
before processing
3. Prevent potential memory crash caused by excessively large shadow
blur radius values

Log: Added shadow blur radius limit to prevent application crash

Influence:
1. Test shadow rendering with various blur radius values (0, 1, 99,
100, 101)
2. Verify normal shadow display with radius within valid range (2-100)
3. Test edge cases: negative radius, radius=0, radius=1
4. Verify application stability when providing invalid radius values
5. Check performance impact with radius at maximum allowed value (100)

fix: 添加阴影模糊半径限制，防止崩溃

1. 在 doBoxShdowBlur 中添加半径超过100的早期返回处理
2. 在 getRawShadow 中添加阴影模糊半径的预处理检查，拒绝无效值
3. 防止因过大的阴影模糊半径值导致的内存崩溃

Log: 新增阴影模糊半径限制，防止应用崩溃

Influence:
1. 测试不同模糊半径值（0， 1， 99, 100, 101）下的阴影渲染
2. 验证有效范围内（2-100）阴影显示正常
3. 测试边界情况：负值半径、半径为0、半径为1
4. 验证使用无效半径值时应用程序的稳定性
5. 检查当半径设为最大值100时的性能影响
