### PR TITLE
Fix DTK titlebar minimize/close buttons disabled on Wayland (winId truncation)

### DIFF
--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -215,7 +215,7 @@ void DQuickWindowAttachedPrivate::_q_onWindowMotifHintsChanged(quint32 winId)
 
     if (!q->window())
         return;
-    if (q->window()->winId() != winId)
+    if (static_cast<quint32>(q->window()->winId()) != winId)
         return;
 
     auto functions_hints = DWindowManagerHelper::getMotifFunctions(q->window());


### PR DESCRIPTION
## Problem

On Wayland, DTK client-side titlebars (e.g. `dde-control-center`) render their **minimize and close buttons permanently disabled** — grayed out, no hover, no action. Only the menu/hamburger button works. The same binaries work correctly on X11 and worked on older Qt.

`WindowButtonGroup.qml` enables minimize/maximize/close only when `D.DWindow.motifFunctions` includes the corresponding `FUNC_*` bit. A runtime probe (a minimal DTK `ApplicationWindow`) shows `motifFunctions` stuck at `0x0` for the window's entire lifetime under a Wayland session.

## Root cause

`DQuickWindowAttachedPrivate::_q_onWindowMotifHintsChanged(quint32 winId)` guards on window identity:

```cpp
if (q->window()->winId() != winId)
    return;
```

The `winId` argument is a **`quint32`** — both callers deliver it truncated to 32 bits: the `SurfaceCreated` path in `eventFilter` casts `static_cast<quint32>(window->winId())`, and the `DWindowManagerHelper::windowMotifWMHintsChanged(quint32)` signal is 32-bit by definition. But the guard compares it against `QWindow::winId()`, which returns the full-width `WId` (`quintptr`).

- On **X11**, `WId` is a 32-bit XID, so the comparison holds.
- On **Wayland with Qt 6.11**, `WId` is a pointer-derived value greater than 32 bits, so `full64 != truncated32` is *always* true. The slot returns early, `DWindowManagerHelper::getMotifFunctions()` is never called, and `motifFunctions` is never updated from its `0` default — leaving all window buttons disabled.

This is why the regression appears "version-less": the DTK sources are unchanged; it is the Qt QtWayland `winId` assignment that shifted, exposing the latent width mismatch.

## Fix

Compare the low 32 bits on both sides, matching the width the codebase already delivers. No public API/ABI change (`windowMotifWMHintsChanged(quint32)` is unchanged).

```cpp
if (static_cast<quint32>(q->window()->winId()) != winId)
    return;
```

## Verification

Minimal reproducer — a DTK `ApplicationWindow` that logs `D.DWindow.motifFunctions` on each poll, run inside a Treeland/Wayland session:

- **Before:** `motifFunctions = 0 (0x0)` for the whole run; minimize/close disabled.
- **After:** `motifFunctions = 62 (0x3e)` (`FUNC_RESIZE|MOVE|MINIMIZE|MAXIMIZE|CLOSE`); minimize/close enabled. `dde-control-center` titlebar buttons hover and work again.
