### PR TITLE
fix(popup): break binding loop in background Loader selection

### DIFF
--- a/qt6/src/qml/Popup.qml
+++ b/qt6/src/qml/Popup.qml
@@ -21,20 +21,18 @@ T.Popup {
 
     padding: DS.Style.popup.padding
 
-    background: Item {
-        implicitWidth: DS.Style.control.implicitWidth(control)
-        implicitHeight: DS.Style.control.implicitHeight(control)
+    background: Loader {
+        sourceComponent: control.popupType === Popup.Window
+                         ? windowBlurComponent : floatingPanelComponent
 
-        Loader {
-            anchors.fill: parent
-            active: control.popupType === Popup.Window
-            sourceComponent: D.StyledBehindWindowBlur { }
+        Component {
+            id: windowBlurComponent
+            D.StyledBehindWindowBlur { }
         }
 
-        Loader {
-            anchors.fill: parent
-            active: control.popupType !== Popup.Window
-            sourceComponent: FloatingPanel {
+        Component {
+            id: floatingPanelComponent
+            FloatingPanel {
                 implicitHeight: DS.Style.popup.height
                 implicitWidth: DS.Style.popup.width
                 radius: DS.Style.popup.radius


### PR DESCRIPTION
1. Replace Item + two mutually-exclusive Loaders with a single Loader using conditional sourceComponent
2. Remove self-referential implicitWidth/Height on background Item that read DS.Style.control.implicitWidth(control), which fed back into control.implicitBackgroundWidth and formed a binding loop

Log: bound the Item's implicitWidth/Height to DS.Style.control.implicitWidth(control), creating a self-referential cycle that produced "Binding loop detected" warnings. Revert to single Loader + conditional sourceComponent.

Influence:
1. Test Popup with Window popupType to verify behind window blur effect
2. Test Popup with non-Window popupType to verify floating panel appearance
3. Cross-test Popup styling and sizing properties
4. Popup.qml:QML binding loop warnings no longer emitted

refactor(popup): 修复 background Loader 选择中的绑定环

1. 将 Item + 两个互斥 Loader 替换为单 Loader 配合条件 sourceComponent
2. 移除 background Item 上自引用的 implicitWidth/Height，其读取 DS.Style.control.implicitWidth(control) 会回灌 control.implicitBackgroundWidth 形成绑定环

Log: Item 的 implicitWidth/Height 绑到 DS.Style.control.implicitWidth(control)，形成自引用环，导致 产生 "Binding loop detected" 警告。还原为单 Loader + 条件 sourceComponent 结构。

Influence:
1. 测试 Window popupType 下的弹出窗口背景模糊效果
2. 测试非 Window popupType 下的浮动面板显示
3. 交叉测试弹出窗口的样式和尺寸属性
4. Popup.qml: QML binding loop 警告不再产生

PMS: TASK-392413

## Summary by Sourcery

Simplify Popup background handling to avoid QML binding loop warnings when selecting between window blur and floating panel backgrounds.

Bug Fixes:
- Remove self-referential implicit sizing bindings on the popup background that caused QML "Binding loop detected" warnings.

Enhancements:
- Replace the background Item and two mutually-exclusive Loaders with a single Loader using conditional sourceComponent for window blur vs. floating panel.