### PR TITLE
chore(DciIcon): change layout timer interval to 55ms for crash identi…

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -222,7 +222,7 @@ void DQuickDciIconImagePrivate::scheduleLayout()
     if (!layoutTimer) {
         layoutTimer = new QTimer(q);
         layoutTimer->setSingleShot(true);
-        layoutTimer->setInterval(50);
+        layoutTimer->setInterval(55);
         QObject::connect(layoutTimer, &QTimer::timeout, q, [this]() {
             layout();
         });


### PR DESCRIPTION
…fication

1. Change DQuickDciIconImage layoutTimer interval from 50ms to 55ms
2. This is a temporary debug marker to identify the timer in coredumps
3. 55ms is unique enough to distinguish from other 50ms QML Timers

Log: Mark DciIcon layout timer with 55ms for crash root cause diagnosis
Influence: No functional change, only timer interval adjusted

chore(DciIcon): 修改 layoutTimer 间隔为 55ms 用于崩溃定位

1. 将 DQuickDciIconImage 的 layoutTimer 间隔从 50ms 改为 55ms
2. 临时调试标记，用于在 coredump 中唯一标识该定时器
3. 55ms 可与其他 50ms QML Timer 来源区分

Log: 标记 DciIcon layoutTimer 为 55ms 用于崩溃根因定位
Influence: 仅调整定时器间隔，无功能变化

## Summary by Sourcery

Enhancements:
- Mark the DciIcon layout timer with a distinctive 55ms interval to facilitate identification in coredumps.