### PR TITLE
fix(DciIcon): stop layout timer in destructor to prevent use-after-free

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -255,7 +255,15 @@ DQuickDciIconImage::DQuickDciIconImage(QQuickItem *parent)
 
 DQuickDciIconImage::~DQuickDciIconImage()
 {
-
+    D_D(DQuickDciIconImage);
+    if (d->imageItem) {
+        d->imageItem->disconnect(this);
+    }
+    if (d->layoutTimer) {
+        d->layoutTimer->stop();
+        delete d->layoutTimer;
+        d->layoutTimer = nullptr;
+    }
 }
 
 QString DQuickDciIconImage::name() const

--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -222,7 +222,7 @@ void DQuickDciIconImagePrivate::scheduleLayout()
     if (!layoutTimer) {
         layoutTimer = new QTimer(q);
         layoutTimer->setSingleShot(true);
-        layoutTimer->setInterval(55);
+        layoutTimer->setInterval(50);
         QObject::connect(layoutTimer, &QTimer::timeout, q, [this]() {
             layout();
         });


### PR DESCRIPTION
## Summary by Sourcery

Prevent use-after-free issues in DQuickDciIconImage by cleaning up timer and connections on destruction and slightly adjusting the layout timer interval.

Bug Fixes:
- Stop and delete the layout timer in DQuickDciIconImage's destructor to avoid callbacks after object destruction.
- Disconnect the image item from the DQuickDciIconImage instance during destruction to prevent use-after-free signal handling.

Enhancements:
- Reduce the layout timer interval from 55ms to 50ms for marginally faster layout updates.