### PR TITLE
fix(window): fix isEnabled() for Windows platform

### DIFF
--- a/src/dquickwindow.cpp
+++ b/src/dquickwindow.cpp
@@ -396,8 +396,14 @@ void DQuickWindowAttached::setWindow(QQuickWindow *window)
 bool DQuickWindowAttached::isEnabled() const
 {
     D_DC(DQuickWindowAttached);
+#ifdef Q_OS_WIN
+    // On Windows, DPlatformHandle doesn't support isEnabledDXcb,
+    // but we still need to report enabled when handle exists
+    return d->handle != nullptr;
+#else
     return d->handle && (DPlatformHandle::isEnabledDXcb(window())
         || DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform));
+#endif
 }
 
 /*!


### PR DESCRIPTION
On Windows, DPlatformHandle doesn't support isEnabledDXcb which is a Linux-specific function. Return handle existence directly instead to ensure the window reports correctly as enabled on Windows.

fix(window): 修复 Windows 平台下 isEnabled() 的兼容性问题

DPlatformHandle::isEnabledDXcb 仅在 Linux 下可用，在 Windows 上直接返回 handle 是否存在以正确报告窗口启用状态。

## Summary by Sourcery

Bug Fixes:
- Ensure DQuickWindowAttached::isEnabled() correctly reports enabled state on Windows by falling back to handle existence when DXcb-specific checks are unavailable.