### PR TITLE
fix: keep ComboBox window popup open during focus transfer

### DIFF
--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -190,11 +190,24 @@ T.ComboBox {
             view.highlightMoveDuration: 0
         }
 
-        background: FloatingPanel {
-            implicitWidth: DS.Style.menu.item.width
-            implicitHeight: DS.Style.menu.item.height
-            radius: DS.Style.menu.radius
-            backgroundColor: DS.Style.menu.background
+        background: Loader {
+            sourceComponent: popup.popupType === T.Popup.Window
+                             ? windowBlurComponent : floatingPanelComponent
+
+            Component {
+                id: windowBlurComponent
+                D.StyledBehindWindowBlur { }
+            }
+
+            Component {
+                id: floatingPanelComponent
+                FloatingPanel {
+                    implicitWidth: DS.Style.menu.item.width
+                    implicitHeight: DS.Style.menu.item.height
+                    radius: DS.Style.menu.radius
+                    backgroundColor: DS.Style.menu.background
+                }
+            }
         }
     }
 }

--- a/qt6/src/qml/Popup.qml
+++ b/qt6/src/qml/Popup.qml
@@ -13,6 +13,7 @@ T.Popup {
 
     palette: D.DTK.palette
     focus: popupType === Popup.Window
+    D.PopupHandle.enabled: popupType === Popup.Window
 
     property bool closeOnInactive: true
     readonly property bool active: parent && parent.Window.active

--- a/src/private/dpopupwindowhandle.cpp
+++ b/src/private/dpopupwindowhandle.cpp
@@ -46,6 +46,8 @@ DPopupWindowHandle::~DPopupWindowHandle()
         m_parentWindow->removeEventFilter(this);
     if (m_popupWin)
         m_popupWin->removeEventFilter(this);
+    if (m_focusOwner)
+        m_focusOwner->removeEventFilter(this);
 }
 
 DPopupWindowHandle::DPopupWindowHandle(QObject *popup)
@@ -147,6 +149,10 @@ void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
         m_parentWindow->removeEventFilter(this);
         m_parentWindow = nullptr;
     }
+    if (m_focusOwner) {
+        m_focusOwner->removeEventFilter(this);
+        m_focusOwner = nullptr;
+    }
 
     // Apply attached properties (blur, radius, etc.) to popup windows.
     if (m_attached) {
@@ -165,6 +171,12 @@ void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
             m_parentWindow = main;
             m_parentWindow->installEventFilter(this);
         }
+
+        auto *owner = qobject_cast<QQuickItem *>(m_popup->property("parent").value<QObject *>());
+        if (owner && owner->inherits("QQuickComboBox")) {
+            m_focusOwner = owner;
+            m_focusOwner->installEventFilter(this);
+        }
     }
 }
 
@@ -178,6 +190,14 @@ void DPopupWindowHandle::onPopupVisibleChanged()
 
 bool DPopupWindowHandle::eventFilter(QObject *watched, QEvent *event)
 {
+    // A window popup takes focus from its ComboBox. Keep that internal focus
+    // transfer from being treated as focus leaving the control altogether.
+    if (watched == m_focusOwner && event->type() == QEvent::FocusOut
+            && isEnabled() && m_popup->property("visible").toBool()
+            && m_popupWin && QGuiApplication::focusWindow() == m_popupWin) {
+        return true;
+    }
+
     if (watched == m_popupWin && event->type() == QEvent::Move) {
         adjustPopupPosition();
     }

--- a/src/private/dpopupwindowhandle_p.h
+++ b/src/private/dpopupwindowhandle_p.h
@@ -72,6 +72,7 @@ private:
     QPointer<QQuickWindow> m_popupWin = nullptr;
     QPointer<QQuickItem> m_trackedItem = nullptr;
     QPointer<QQuickItem> m_restoreFocusItem = nullptr;
+    QPointer<QQuickItem> m_focusOwner = nullptr;
     bool m_popupFocusRequested = false;
 };
 

--- a/tests/ut_dtkdeclatative_qmls.cpp
+++ b/tests/ut_dtkdeclatative_qmls.cpp
@@ -1,11 +1,19 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <gtest/gtest.h>
 
 #include "test_helper.hpp"
+#include "dpopupwindowhandle_p.h"
 #include <QQmlModuleRegistration>
+#include <QQuickItem>
+#include <QQuickWindow>
+#if QT_VERSION_MAJOR >= 6
+#include <qpa/qwindowsysteminterface.h>
+#endif
+
+DQUICK_USE_NAMESPACE
 
 class ut_dtkDeclarativeQmls : public ::testing::TestWithParam<std::string> {
 public:
@@ -148,6 +156,94 @@ public:
         };
     }
 };
+
+#if QT_VERSION_MAJOR >= 6
+TEST(ut_DPopupWindowHandle, popupWindowCreatesHandle)
+{
+    ControlHelper<> helper;
+    const QByteArray data(R"(
+        import QtQuick
+        import QtQuick.Controls
+        import org.deepin.dtk 1.0 as D
+
+        Item {
+            property alias popup: popup
+
+            D.Popup {
+                id: popup
+                popupType: Popup.Window
+            }
+        }
+    )");
+
+    ASSERT_TRUE(helper.setData(data));
+    QObject *popup = qvariant_cast<QObject *>(helper.object->property("popup"));
+    ASSERT_TRUE(popup);
+    EXPECT_TRUE(qmlAttachedPropertiesObject<DPopupWindowHandle>(popup, false));
+}
+
+TEST(ut_DPopupWindowHandle, comboBoxKeepsPopupOpenWhenFocusMovesToPopupWindow)
+{
+    ControlHelper<QQuickWindow> helper;
+    const QByteArray data(R"(
+        import QtQuick
+        import QtQuick.Templates as T
+        import org.deepin.dtk 1.0 as D
+
+        Window {
+            width: 400
+            height: 300
+            property alias control: control
+
+            T.ComboBox {
+                id: control
+                width: 200
+                model: 3
+                popup: D.Popup {
+                    width: 200
+                    height: 160
+                    popupType: T.Popup.Window
+                    focus: false
+                    closeOnInactive: false
+                    contentItem: Item { }
+                }
+            }
+        }
+    )");
+
+    ASSERT_TRUE(helper.setData(data));
+    helper.requestExposed();
+
+    auto *control = qvariant_cast<QQuickItem *>(helper.object->property("control"));
+    ASSERT_TRUE(control);
+    auto *popup = qvariant_cast<QObject *>(control->property("popup"));
+    ASSERT_TRUE(popup);
+
+    QWindowSystemInterface::handleFocusWindowChanged(helper.object, Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+    control->forceActiveFocus(Qt::OtherFocusReason);
+    ASSERT_TRUE(control->hasActiveFocus());
+
+    ASSERT_TRUE(QMetaObject::invokeMethod(popup, "open", Qt::DirectConnection));
+    QCoreApplication::processEvents();
+    ASSERT_TRUE(popup->property("visible").toBool());
+
+    auto *contentItem = qvariant_cast<QQuickItem *>(popup->property("contentItem"));
+    ASSERT_TRUE(contentItem);
+    QQuickWindow *popupWindow = contentItem->window();
+    ASSERT_TRUE(popupWindow);
+    ASSERT_NE(popupWindow, helper.object);
+
+    QWindowSystemInterface::handleFocusWindowChanged(popupWindow, Qt::PopupFocusReason);
+    QCoreApplication::processEvents();
+
+    EXPECT_TRUE(popup->property("visible").toBool());
+
+    QWindowSystemInterface::handleFocusWindowChanged(helper.object, Qt::PopupFocusReason);
+    QMetaObject::invokeMethod(popup, "close", Qt::DirectConnection);
+    QCoreApplication::processEvents();
+}
+#endif
 
 TEST_P(ut_dtkDeclarativeQmls, load)
 {

--- a/tests/ut_dtkdeclatative_qmls.cpp
+++ b/tests/ut_dtkdeclatative_qmls.cpp
@@ -158,6 +158,57 @@ public:
 };
 
 #if QT_VERSION_MAJOR >= 6
+TEST(ut_DComboBox, popupTypeSelectsMatchingBackground)
+{
+    ControlHelper<> helper;
+    const QByteArray data(R"(
+        import QtQuick
+        import QtQuick.Templates as T
+        import org.deepin.dtk 1.0 as D
+
+        Item {
+            property alias itemPopup: itemCombo.popup
+            property alias windowPopup: windowCombo.popup
+
+            D.ComboBox {
+                id: itemCombo
+                popup.popupType: T.Popup.Item
+            }
+
+            D.ComboBox {
+                id: windowCombo
+                popup.popupType: T.Popup.Window
+            }
+        }
+    )");
+
+    ASSERT_TRUE(helper.setData(data));
+    const auto effectiveBackground = [&helper](const char *popupProperty) {
+        QObject *popup = qvariant_cast<QObject *>(helper.object->property(popupProperty));
+        if (!popup)
+            return static_cast<QObject *>(nullptr);
+
+        QObject *background = qvariant_cast<QObject *>(popup->property("background"));
+        if (!background)
+            return static_cast<QObject *>(nullptr);
+
+        QObject *item = qvariant_cast<QObject *>(background->property("item"));
+        return item ? item : background;
+    };
+
+    QObject *itemBackground = effectiveBackground("itemPopup");
+    ASSERT_TRUE(itemBackground);
+    EXPECT_TRUE(QString::fromLatin1(itemBackground->metaObject()->className()).contains("FloatingPanel"));
+
+    QObject *windowBackground = effectiveBackground("windowPopup");
+    ASSERT_TRUE(windowBackground);
+    EXPECT_TRUE(QString::fromLatin1(windowBackground->metaObject()->className()).contains("StyledBehindWindowBlur"))
+            << windowBackground->metaObject()->className();
+
+    delete helper.object;
+    helper.object = nullptr;
+}
+
 TEST(ut_DPopupWindowHandle, popupWindowCreatesHandle)
 {
     ControlHelper<> helper;


### PR DESCRIPTION
## Summary

- Enable `PopupHandle` when a DTK popup uses `Popup.Window`.
- Ignore the ComboBox `FocusOut` event only when focus moves into its own popup window, preventing the popup from closing immediately.
- Select the ComboBox background by popup type: `Popup.Window` uses behind-window blur while `Popup.Item` keeps `FloatingPanel`.
- Add regression tests for popup handle creation, ComboBox focus transfer, and both background variants.

## Verification

- Built the `unit-test` target successfully.
- Passed `ut_DComboBox.*:ut_DPopupWindowHandle.*` (3/3) with the offscreen platform.
- Passed the new ComboBox background test with both offscreen and xcb/Xvfb platforms.
- Built `dtk6declarative_qmllint` successfully.
- Deployed the DTK-only package with the original Qt package on Treeland: 10/10 rounds passed, 4/4 runtime checks per round.
- Verified the original Qt negative control still reproduces the focus-close behavior, confirming the fix is provided by DTK rather than a residual Qt patch.
- Verified on the target machine that `Popup.Window` uses the expected behind-window blur background.

## Bug

BUG-371355