### PR TITLE
fix(dtkdeclarative): prevent startTimer warning when event dispatcher is unavailable

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -482,7 +482,10 @@ void DQuickDciIconImage::geometryChange(const QRectF &newGeometry, const QRectF 
 void DQuickDciIconImage::itemChange(ItemChange change, const ItemChangeData &value)
 {
     QQuickItem::itemChange(change, value);
-    if (change == ItemParentHasChanged || change == ItemDevicePixelRatioHasChanged || change == ItemSceneChange) {
+
+    if ((change == ItemParentHasChanged && parentItem()) 
+        || change == ItemDevicePixelRatioHasChanged 
+        || change == ItemSceneChange) {
         d_func()->scheduleLayout();
     }
 }


### PR DESCRIPTION
DQuickDciIconImage::scheduleLayout() may be invoked via itemChange() or geometryChange() hooks during the destruction of ListView delegate items reparented to QCoreApplication via QQmlDelegateModel. At that point, ~QCoreApplication() has already set eventDispatcher to nullptr , causing QObject::startTimer() to emit:
  "QObject::startTimer: Timers can only be used with threads started
   with QThread"

Log: Fix startTimer warning for DciIcon

Influence:
  1. DciIcon displays correctly;
  2. When the program exits, DciIcon in containers such as ListView and Repeater does not have a startTimer warning

fix(dtkdeclarative): 修复 eventDispatcher 不可用时 startTimer 告警

ListView delegate item 经 QQmlDelegateModel 重挂到 QCoreApplication 后，在 ~QCoreApplication() 的 ~QObject::deleteChildren() 阶段析构。 此时 itemChange()/geometryChange() 钩子触发 scheduleLayout() → QTimer::start() → QObject::startTimer()，但 ~QCoreApplication() 体 已在基类析构体之前将 eventDispatcher 置空，导致以下告警:
  "QObject::startTimer: Timers can only be used with threads started
   with QThread"

Log: 修复DciIcon的startTimer警告

Influence:
  1.DciIcon正确显示；
  2.程序退出时，ListView、Repeater等容器中的DciIcon没有startTimer警告

PMS: TASK-392413

## Summary by Sourcery

Bug Fixes:
- Avoid QObject::startTimer warnings for DciIcon items when the event dispatcher is unavailable during application teardown.