### PR TITLE
fix(popup): remove focus workaround

### DIFF
--- a/src/private/dpopupwindowhandle.cpp
+++ b/src/private/dpopupwindowhandle.cpp
@@ -7,15 +7,13 @@
 
 #include <QQuickItem>
 #include <QQuickWindow>
-#include <QPointer>
 #include <QScreen>
 #include <QGuiApplication>
-#include <QDebug>
 #include <QMouseEvent>
 #include <algorithm>
 
 #include <private/qquickitem_p.h>
-#include <qpa/qwindowsysteminterface.h>
+#include <qcoreevent.h>
 
 DQUICK_BEGIN_NAMESPACE
 
@@ -46,8 +44,6 @@ DPopupWindowHandle::~DPopupWindowHandle()
         m_parentWindow->removeEventFilter(this);
     if (m_popupWin)
         m_popupWin->removeEventFilter(this);
-    if (m_focusOwner)
-        m_focusOwner->removeEventFilter(this);
 }
 
 DPopupWindowHandle::DPopupWindowHandle(QObject *popup)
@@ -64,7 +60,6 @@ DPopupWindowHandle::DPopupWindowHandle(QObject *popup)
     popupItemReparented();
 
     connect(popup, SIGNAL(popupTypeChanged()), this, SLOT(updateEnabled()));
-    connect(popup, SIGNAL(visibleChanged()), this, SLOT(onPopupVisibleChanged()));
 }
 
 DQuickWindowAttached *DPopupWindowHandle::qmlAttachedProperties(QObject *object)
@@ -137,8 +132,6 @@ bool DPopupWindowHandle::isEnabled() const
 
 void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
 {
-    if (!window)
-        restoreParentFocus();
 
     // Cleanup old filters
     if (m_popupWin) {
@@ -148,10 +141,6 @@ void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
     if (m_parentWindow) {
         m_parentWindow->removeEventFilter(this);
         m_parentWindow = nullptr;
-    }
-    if (m_focusOwner) {
-        m_focusOwner->removeEventFilter(this);
-        m_focusOwner = nullptr;
     }
 
     // Apply attached properties (blur, radius, etc.) to popup windows.
@@ -172,39 +161,16 @@ void DPopupWindowHandle::onWindowChanged(QQuickWindow *window)
             m_parentWindow->installEventFilter(this);
         }
 
-        auto *owner = qobject_cast<QQuickItem *>(m_popup->property("parent").value<QObject *>());
-        if (owner && owner->inherits("QQuickComboBox")) {
-            m_focusOwner = owner;
-            m_focusOwner->installEventFilter(this);
-        }
     }
 }
 
-void DPopupWindowHandle::onPopupVisibleChanged()
-{
-    if (!m_popup || m_popup->property("visible").toBool())
-        return;
-
-    restoreParentFocus();
-}
 
 bool DPopupWindowHandle::eventFilter(QObject *watched, QEvent *event)
 {
-    // A window popup takes focus from its ComboBox. Keep that internal focus
-    // transfer from being treated as focus leaving the control altogether.
-    if (watched == m_focusOwner && event->type() == QEvent::FocusOut
-            && isEnabled() && m_popup->property("visible").toBool()
-            && m_popupWin && QGuiApplication::focusWindow() == m_popupWin) {
-        return true;
-    }
-
     if (watched == m_popupWin && event->type() == QEvent::Move) {
         adjustPopupPosition();
     }
 
-    if (watched == m_popupWin && event->type() == QEvent::Show) {
-        requestPopupFocus();
-    }
 
     bool pressedOutside = false;
 
@@ -343,51 +309,7 @@ void DPopupWindowHandle::adjustPopupPosition()
         m_popupWin->setPosition(newPos);
 }
 
-void DPopupWindowHandle::requestPopupFocus()
-{
-    if (!m_popup || !isEnabled() || !m_popupWin || !m_popupWin->isVisible())
-        return;
-    if (!m_popup->property("focus").toBool())
-        return;
 
-    m_restoreFocusItem = m_parentWindow ? m_parentWindow->activeFocusItem() : nullptr;
-
-    QMetaObject::invokeMethod(this, [this] {
-        if (!isEnabled() || !m_popup->property("focus").toBool() || !m_popupWin || !m_popupWin->isVisible())
-            return;
-
-        QPointer<QQuickItem> item = popupItem();
-        if (!item || item->window() != m_popupWin)
-            return;
-
-        m_popupFocusRequested = true;
-        m_popupWin->requestActivate();
-    }, Qt::QueuedConnection);
-}
-
-void DPopupWindowHandle::restoreParentFocus()
-{
-    if (!m_popupFocusRequested)
-        return;
-
-    m_popupFocusRequested = false;
-
-    if (!m_popupWin || !m_parentWindow || !m_parentWindow->isVisible()) {
-        m_restoreFocusItem.clear();
-        return;
-    }
-
-    m_parentWindow->requestActivate();
-    if (QGuiApplication::focusWindow() == m_popupWin)
-        QWindowSystemInterface::handleFocusWindowChanged(m_parentWindow, Qt::PopupFocusReason);
-
-    if (m_restoreFocusItem && m_restoreFocusItem->window() == m_parentWindow
-            && m_restoreFocusItem->isVisible() && m_restoreFocusItem->isEnabled()) {
-        m_restoreFocusItem->forceActiveFocus(Qt::OtherFocusReason);
-    }
-
-    m_restoreFocusItem.clear();
-}
 
 DQUICK_END_NAMESPACE
 

--- a/src/private/dpopupwindowhandle_p.h
+++ b/src/private/dpopupwindowhandle_p.h
@@ -51,7 +51,6 @@ protected:
 private Q_SLOTS:
     void updateEnabled();
     void onWindowChanged(QQuickWindow *window);
-    void onPopupVisibleChanged();
 
 private:
     QQuickWindow *popupWindow() const;
@@ -60,8 +59,6 @@ private:
 
     bool isEnabled() const;
     void adjustPopupPosition();
-    void requestPopupFocus();
-    void restoreParentFocus();
     
 private:
     QObject *m_popup = nullptr;
@@ -71,9 +68,6 @@ private:
     QPointer<QQuickWindow> m_parentWindow = nullptr;
     QPointer<QQuickWindow> m_popupWin = nullptr;
     QPointer<QQuickItem> m_trackedItem = nullptr;
-    QPointer<QQuickItem> m_restoreFocusItem = nullptr;
-    QPointer<QQuickItem> m_focusOwner = nullptr;
-    bool m_popupFocusRequested = false;
 };
 
 DQUICK_END_NAMESPACE

--- a/tests/ut_dtkdeclatative_qmls.cpp
+++ b/tests/ut_dtkdeclatative_qmls.cpp
@@ -7,11 +7,6 @@
 #include "test_helper.hpp"
 #include "dpopupwindowhandle_p.h"
 #include <QQmlModuleRegistration>
-#include <QQuickItem>
-#include <QQuickWindow>
-#if QT_VERSION_MAJOR >= 6
-#include <qpa/qwindowsysteminterface.h>
-#endif
 
 DQUICK_USE_NAMESPACE
 
@@ -233,67 +228,6 @@ TEST(ut_DPopupWindowHandle, popupWindowCreatesHandle)
     EXPECT_TRUE(qmlAttachedPropertiesObject<DPopupWindowHandle>(popup, false));
 }
 
-TEST(ut_DPopupWindowHandle, comboBoxKeepsPopupOpenWhenFocusMovesToPopupWindow)
-{
-    ControlHelper<QQuickWindow> helper;
-    const QByteArray data(R"(
-        import QtQuick
-        import QtQuick.Templates as T
-        import org.deepin.dtk 1.0 as D
-
-        Window {
-            width: 400
-            height: 300
-            property alias control: control
-
-            T.ComboBox {
-                id: control
-                width: 200
-                model: 3
-                popup: D.Popup {
-                    width: 200
-                    height: 160
-                    popupType: T.Popup.Window
-                    focus: false
-                    closeOnInactive: false
-                    contentItem: Item { }
-                }
-            }
-        }
-    )");
-
-    ASSERT_TRUE(helper.setData(data));
-    helper.requestExposed();
-
-    auto *control = qvariant_cast<QQuickItem *>(helper.object->property("control"));
-    ASSERT_TRUE(control);
-    auto *popup = qvariant_cast<QObject *>(control->property("popup"));
-    ASSERT_TRUE(popup);
-
-    QWindowSystemInterface::handleFocusWindowChanged(helper.object, Qt::OtherFocusReason);
-    QCoreApplication::processEvents();
-    control->forceActiveFocus(Qt::OtherFocusReason);
-    ASSERT_TRUE(control->hasActiveFocus());
-
-    ASSERT_TRUE(QMetaObject::invokeMethod(popup, "open", Qt::DirectConnection));
-    QCoreApplication::processEvents();
-    ASSERT_TRUE(popup->property("visible").toBool());
-
-    auto *contentItem = qvariant_cast<QQuickItem *>(popup->property("contentItem"));
-    ASSERT_TRUE(contentItem);
-    QQuickWindow *popupWindow = contentItem->window();
-    ASSERT_TRUE(popupWindow);
-    ASSERT_NE(popupWindow, helper.object);
-
-    QWindowSystemInterface::handleFocusWindowChanged(popupWindow, Qt::PopupFocusReason);
-    QCoreApplication::processEvents();
-
-    EXPECT_TRUE(popup->property("visible").toBool());
-
-    QWindowSystemInterface::handleFocusWindowChanged(helper.object, Qt::PopupFocusReason);
-    QMetaObject::invokeMethod(popup, "close", Qt::DirectConnection);
-    QCoreApplication::processEvents();
-}
 #endif
 
 TEST_P(ut_dtkDeclarativeQmls, load)


### PR DESCRIPTION
## Summary

- remove native popup activation and parent focus restoration from `PopupHandle`
- remove ComboBox focus-event filtering now that QtBase owns popup input focus propagation
- remove the obsolete workaround test while retaining popup handle creation coverage

## Verification

- rebuilt `unit-test`
- `ut_DPopupWindowHandle.popupWindowCreatesHandle`: passed
- `ut_DComboBox.popupTypeSelectsMatchingBackground`: passed

Requires: https://github.com/deepin-community/qt6-base/pull/55
PMS: https://pms.uniontech.com/bug-view-372273.html

## Summary by Sourcery

Simplify popup window handling now that QtBase manages popup focus, and clean up related tests.

Bug Fixes:
- Remove custom focus transfer handling between ComboBox and popup windows that is now redundant with QtBase popup focus propagation.

Enhancements:
- Drop obsolete focus ownership tracking and event filtering from DPopupWindowHandle to rely on standard Qt focus behavior.
- Remove the legacy ComboBox focus workaround test while keeping coverage of popup handle creation.