### PR TITLE
fix: use polish for layout scheduling in Qt6

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -67,6 +67,16 @@ DQuickDciIconImageItemPrivate::DQuickDciIconImageItemPrivate(DQuickDciIconImageP
 
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool DQuickDciIconImageItemPrivate::transformChanged(QQuickItem *transformedItem)
+{
+    const bool observesTransform = DQuickIconImagePrivate::transformChanged(transformedItem);
+    if (transformedItem != q_func())
+        parentPriv->scheduleLayout();
+    return observesTransform;
+}
+#endif
+
 void DQuickDciIconImageItemPrivate::maybeUpdateUrl()
 {
     Q_Q(DQuickIconImage);
@@ -218,7 +228,9 @@ void DQuickDciIconImagePrivate::layout()
 void DQuickDciIconImagePrivate::scheduleLayout()
 {
     Q_Q(DQuickDciIconImage);
-
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    q->polish();
+#else
     if (!layoutTimer) {
         layoutTimer = new QTimer(q);
         layoutTimer->setSingleShot(true);
@@ -228,6 +240,7 @@ void DQuickDciIconImagePrivate::scheduleLayout()
         });
     }
     layoutTimer->start();
+#endif
 }
 
 void DQuickDciIconImagePrivate::updateImageSourceUrl()
@@ -245,6 +258,9 @@ DQuickDciIconImage::DQuickDciIconImage(QQuickItem *parent)
     , DObject(*new DQuickDciIconImagePrivate(this))
 {
     D_D(DQuickDciIconImage);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    d->imageItem->setFlag(QQuickItem::ItemObservesViewport);
+#endif
     connect(d->imageItem, &QQuickImage::implicitWidthChanged, this, [this, d]() { setImplicitWidth(d->imageItem->implicitWidth()); });
     connect(d->imageItem, &QQuickImage::implicitHeightChanged, this, [this, d]() { setImplicitHeight(d->imageItem->implicitHeight()); });
     connect(this, &DQuickDciIconImage::smoothChanged, d->imageItem, &QQuickImage::setSmooth);
@@ -448,6 +464,14 @@ DQuickIconAttached *DQuickDciIconImage::qmlAttachedProperties(QObject *object)
 
     return new DQuickIconAttached(item);
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void DQuickDciIconImage::updatePolish()
+{
+    D_D(DQuickDciIconImage);
+    d->layout();
+}
+#endif
 
 void DQuickDciIconImage::classBegin()
 {

--- a/src/private/dquickdciiconimage_p.h
+++ b/src/private/dquickdciiconimage_p.h
@@ -104,6 +104,9 @@ Q_SIGNALS:
 
 protected:
     void classBegin() override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void updatePolish() override;
+#endif
     void componentComplete() override;
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;

--- a/src/private/dquickdciiconimage_p_p.h
+++ b/src/private/dquickdciiconimage_p_p.h
@@ -23,6 +23,9 @@ class DQuickDciIconImageItemPrivate : public DQuickIconImagePrivate
 
 public:
     DQuickDciIconImageItemPrivate(DQuickDciIconImagePrivate *pqq);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool transformChanged(QQuickItem *transformedItem) override;
+#endif
     void maybeUpdateUrl();
     void play(int mode);
     QUrlQuery getUrlQuery();


### PR DESCRIPTION
1. Replace QTimer-based layout scheduling with QQuickItem::polish()
in Qt6
2. Override updatePolish() to perform immediate layout during polish
phase
3. Set ItemObservesViewport flag on image item for proper transform
observation
4. Add transformChanged() override to trigger parent layout on transform
changes

In Qt6, QTimer-based layout scheduling is inefficient and can
cause visual delays. Using QQuickItem::polish() integrates layout
updates with Qt's rendering pipeline, ensuring layout happens before
painting and providing better performance and visual consistency. The
transformChanged override enables proper viewport observation and parent
layout updates when the item transforms.

Log: Improved layout performance for DCI icon images in Qt6

Influence:
1. Test rendering of DCI icons in various states (normal, hover,
pressed, disabled)
2. Verify animated DCI icon transitions render smoothly
3. Test layout updates when parent container size changes
4. Verify DCI icon positioning and alignment in different layouts
5. Test with both integer and non-integer scale factors
6. Verify performance metrics (fps, CPU usage) during DCI icon
animations
7. Test normal animation functionality without icon state changes

fix: Qt6 下使用 polish 进行布局调度

1. Qt6 中使用 QQuickItem::polish() 替代基于 QTimer 的布局调度
2. 重写 updatePolish() 在 polish 阶段执行即时布局
3. 在图像项上设置 ItemObservesViewport 标志以确保正确的变换观察
4. 添加 transformChanged() 重写以在变换变化时触发父级布局

在 Qt6 中，基于 QTimer 的布局调度效率低下且可能造成视觉延迟。使用
QQuickItem::polish() 可以将布局更新集成到 Qt 的渲染流程中，确保布局在绘
制前完成，提供更好的性能和视觉一致性。transformChanged 重写可以在项变换
时实现正确的视口观察和父级布局更新。

Log: 优化 Qt6 中 DCI 图标图像的布局性能

Influence:
1. 测试各种状态下 DCI 图标的渲染（普通、悬停、按压、禁用）
2. 验证 DCI 图标动画过渡是否流畅
3. 测试父容器大小变化时的布局更新
4. 验证不同布局中 DCI 图标的位置和对齐
5. 测试整数和非整数缩放因子
6. 在 DCI 图标动画期间验证性能指标（帧率、CPU 使用率）
7. 测试无图标状态变化的普通动画功能

PMS: BUG-370155

## Summary by Sourcery

Integrate Qt6 polish-based layout scheduling for DCI icon images to align layout updates with the rendering pipeline and improve visual performance.

New Features:
- Use QQuickItem::polish() for layout scheduling on Qt6 instead of QTimer-based timers.
- Trigger immediate layout in the polish phase via an updatePolish() override on DQuickDciIconImage.
- Enable viewport transform observation for the internal image item using the ItemObservesViewport flag on Qt6.

Bug Fixes:
- Ensure parent layout is rescheduled when the image item's transform changes by overriding transformChanged() in Qt6 builds.