### PR TITLE
fix(slider): add NoArrowType case in SliderHandle

### DIFF
--- a/qt6/src/qml/SliderHandle.qml
+++ b/qt6/src/qml/SliderHandle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -24,6 +24,9 @@ D.DciIcon {
             return "slider_point_left"
         case Slider.HandleType.ArrowRight:
             return "slider_point_left"
+        case Slider.HandleType.NoArrowType:
+        default:
+            return ""
         }
     }
 


### PR DESCRIPTION
## 背景

控制中心-系统-声音页运行时出现告警：

```
qrc:/org/deepin/dtk/SliderHandle.qml:32:5: Unable to assign [undefined] to QString
```

触发点为 `dde-control-center` 的 `MicrophonePage.qml` 中输入等级反馈条 Slider 设置了 `handleType: Slider.HandleType.NoArrowType`。关联 issue：**DDE-115**。

## 根因

`qt6/src/qml/Slider.qml` 的 `HandleType` 枚举由 commit `bdc27e7` 新增了 `NoArrowType`，但同次改动**漏改了** `qt6/src/qml/SliderHandle.qml` 的 `getIconNameByType(handleType)`：该 `switch` 仅覆盖 `NoArrowHorizontal/NoArrowVertical/ArrowUp/ArrowBottom/ArrowLeft/ArrowRight`（0~5），**没有 `NoArrowType` 的 case**，也**没有 `default` 分支**。

当传入 `NoArrowType` 时，`switch` 无匹配，函数走到底返回 JS `undefined`，该返回值在第 32 行赋给 `D.DciIcon` 的 `name` 属性（`name: getIconNameByType(type)`）。`name` 在 C++ 侧为 `Q_PROPERTY(QString name ...)`，QML 把 `undefined` 赋给 `QString` 即触发 `Unable to assign [undefined] to QString`，行列号 `32:5` 正对应 `    name:` 这一行。

## 修复

在 `getIconNameByType` 的 `switch` 末尾、`ArrowRight` case 之后补一个 `NoArrowType` 分支，并 fall-through 到 `default` 共享同一个空串返回 `""`：

```qml
        case Slider.HandleType.NoArrowType:
        default:
            return ""
```

`NoArrowType` 返回 `""` 的依据：`DciIcon` 的 C++ 实现（`src/private/dquickdciiconimage.cpp`）以 `imageItem->name().isEmpty()` 作为"无图标/跳过 DCI 绘制"的哨兵判定，空串是框架既有的、被正确处理的"不绘制"值。`NoArrowType` 语义即"无箭头/无旋钮图标"，返回 `""` 与语义和实现都对齐，告警消除。

`NoArrowType` case 不单独 `return`，而是 fall-through 到紧随其后的 `default` 分支，两者共享同一个 `return ""`，简洁且避免重复。`default` 分支同时对任何未来新增的 `HandleType` 枚举值返回空串，避免再次出现未覆盖枚举导致 `undefined` 赋给 `QString` 的问题，起到防御性硬化作用。

按规范更新该文件顶部 `SPDX-FileCopyrightText` 年份范围为 `2022 - 2026`。

## 改动范围

- 仅 `qt6/src/qml/SliderHandle.qml` 一处（+4/-1）。
- `getIconNameByType` 既有 6 个 case 顺序与返回值不变，新增 `NoArrowType` case 不影响既有分支行为。
- `NoArrowType` case fall-through 到 `default` 分支，共享同一个 `return ""`，覆盖 `NoArrowType` 及未来新增枚举值，防御性返回空串。
- 顶部 `SPDX-FileCopyrightText` 年份改为 `2022 - 2026`，其余 SPDX 头部行不变。
- Qt5 路径 `src/qml/Slider.qml` 不定义 `NoArrowType`，按维护规则不改 Qt5。
- 不涉及 C++/ABI/DBus/DConfig，纯 QML 最小 diff。

## diff

```diff
--- a/qt6/src/qml/SliderHandle.qml
+++ b/qt6/src/qml/SliderHandle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
@@ -24,6 +24,9 @@ D.DciIcon {
             return "slider_point_left"
         case Slider.HandleType.ArrowRight:
             return "slider_point_left"
+        case Slider.HandleType.NoArrowType:
+        default:
+            return ""
         }
```

## 验证建议

1. 打开控制中心-系统-声音-输入页，日志中不再出现 `SliderHandle.qml:32:5: Unable to assign [undefined] to QString`。
2. 麦克风输入等级电平条随输入正常起伏、无残留图标/占位闪烁。
3. 其他 Slider（音量、亮度、字体等使用 `ArrowBottom`/`NoArrowHorizontal`）行为不变。

## 状态

此 PR 为 **draft / 待审核** 状态，请勿直接合并。已通过同线程代码审核与本地编译打包验证（详见 issue DDE-115 评论区）。

## 关联

- 关联 issue: DDE-115
- PMS: Task-392413

## Summary by Sourcery

Handle icon resolution for arrowless and unknown slider handle types without producing invalid QML property values.

Bug Fixes:
- Prevent undefined icon names for sliders using NoArrowType, eliminating the QML QString assignment warning and preserving icon-free slider handles.

Enhancements:
- Add a default fallback for unrecognized slider handle types to return an empty icon name.

Chores:
- Update the SPDX copyright year range for SliderHandle.qml.