### PR TITLE
fix: emit themeTypeChanged signal on theme switch and add cross-platform build support

### DIFF
--- a/src/private/dqmlglobalobject.cpp
+++ b/src/private/dqmlglobalobject.cpp
@@ -149,6 +149,7 @@ void DQMLGlobalObjectPrivate::ensurePalette()
 #endif
 
     paletteInit = true;
+    previousThemeType = DGuiApplicationHelper::instance()->themeType();
     updatePalettes();
 
     QObject::connect(DGuiApplicationHelper::instance(), SIGNAL(applicationPaletteChanged()), q_func(), SLOT(_q_onPaletteChanged()));
@@ -173,8 +174,15 @@ void DQMLGlobalObjectPrivate::updatePalettes()
 
 void DQMLGlobalObjectPrivate::_q_onPaletteChanged()
 {
+    auto newThemeType = DGuiApplicationHelper::instance()->themeType();
+    bool themeTypeChanged = (previousThemeType != DGuiApplicationHelper::UnknownType && previousThemeType != newThemeType);
+    previousThemeType = newThemeType;
+
     updatePalettes();
 
+    if (themeTypeChanged) {
+        Q_EMIT q_func()->themeTypeChanged(newThemeType);
+    }
     Q_EMIT q_func()->paletteChanged();
     Q_EMIT q_func()->inactivePaletteChanged();
 }

--- a/src/private/dqmlglobalobject_p_p.h
+++ b/src/private/dqmlglobalobject_p_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include <DObjectPrivate>
 #include <DObject>
 #include <DWindowManagerHelper>
+#include <DGuiApplicationHelper>
 
 #include "dqmlglobalobject_p.h"
 
@@ -26,6 +27,7 @@ public:
     mutable DPlatformThemeProxy *platformTheme = nullptr;
 
     bool paletteInit = false;
+    DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType previousThemeType = DTK_GUI_NAMESPACE::DGuiApplicationHelper::UnknownType;
     QPalette palette;
     QPalette inactivePalette;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/targets.cmake
+++ b/src/targets.cmake
@@ -20,7 +20,9 @@ find_package(Dtk${DTK_NAME_SUFFIX}Core REQUIRED)
 find_package(Dtk${DTK_NAME_SUFFIX}Gui REQUIRED)
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
+if(LINUX)
+    pkg_check_modules(GL REQUIRED IMPORTED_TARGET gl)
+endif()
 
 include(${PROJECT_SOURCE_DIR}/src/src.cmake)
 
@@ -61,8 +63,13 @@ target_link_libraries(${LIB_NAME}_properties INTERFACE
     Dtk${DTK_NAME_SUFFIX}::Gui
     $<BUILD_INTERFACE:Qt${QT_VERSION_MAJOR}::QuickPrivate>
     $<BUILD_INTERFACE:Qt${QT_VERSION_MAJOR}::DBus>
-    $<BUILD_INTERFACE:PkgConfig::GL>
 )
+
+if(LINUX)
+    target_link_libraries(${LIB_NAME}_properties INTERFACE $<BUILD_INTERFACE:PkgConfig::GL>)
+else()
+    target_link_libraries(${LIB_NAME}_properties INTERFACE $<BUILD_INTERFACE:opengl32>)
+endif()
 
 target_include_directories(${LIB_NAME}_properties INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>


### PR DESCRIPTION
- Detect theme type change on palette update and emit themeTypeChanged signal when changed
- Make GL dependency Linux-only in CMake, use opengl32 on Windows instead

fix: 修复主题切换时 themeTypeChanged 信号未发射的问题，并支持跨平台编译

- 在调色板变化时检测主题类型是否改变，若改变则发射 themeTypeChanged 信号
- CMake 中将 GL 依赖改为仅 Linux 平台，Windows 使用 opengl32 替代

## Summary by Sourcery

Ensure theme changes notify QML consumers and support platform-appropriate OpenGL dependencies.

Bug Fixes:
- Emit the `themeTypeChanged` signal when a palette update changes the application theme type.

Enhancements:
- Add cross-platform OpenGL linking by using the Linux GL dependency only on Linux and `opengl32` on Windows and other non-Linux platforms.

Build:
- Make OpenGL dependency discovery and linking platform-specific in CMake.