### PR TITLE
fix: adjust QuickPrivate dependency for Qt 6.10+

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,10 @@ find_package(Dtk${DTK_NAME_SUFFIX}Gui REQUIRED)
 find_package(GTest REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Quick QuickControls2 Qml Test)
 if (NOT DTK5)
-    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS QuickPrivate)
+   if (${Qt6Quick_VERSION} VERSION_GREATER_EQUAL "6.10.0")
+        set(QT_NO_PRIVATE_MODULE_WARNING ON)
+        find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS QuickPrivate)
+    endif()
 endif()
 
 file(GLOB TEST_SOURCES


### PR DESCRIPTION
1. Update tests/CMakeLists.txt to conditionally find QuickPrivate module
2. Add QT_NO_PRIVATE_MODULE_WARNING variable to suppress warnings for
Qt 6.10+
3. Restrict QuickPrivate lookup to Qt 6.10.0 and newer versions to
handle API changes
4. Ensure backward compatibility by keeping the search undefined for
older Qt versions
5. Verify that a version check for Qt6Quick is included before
attempting to find the private module

Log: Fixed build compatibility for Qt 6.10+ by adjusting QuickPrivate
dependency detection

Influence:
1. Test with Qt versions below 6.10.0 to confirm no regression
2. Test with Qt 6.10.0 and above to verify successful build
3. Check that the QT_NO_PRIVATE_MODULE_WARNING setting does not
interfere with other modules
4. Verify tests compile and run successfully across different Qt
configurations

fix: 调整 Qt 6.10+ 的 QuickPrivate 依赖

1. 更新 tests/CMakeLists.txt，条件性查找 QuickPrivate 模块
2. 添加 QT_NO_PRIVATE_MODULE_WARNING 变量以抑制 Qt 6.10+ 的警告
3. 将 QuickPrivate 查找限制在 Qt 6.10.0 及更高版本，以处理 API 变化
4. 确保旧版 Qt 保持向后兼容性，不进行该查找
5. 验证在查找私有模块前包含 Qt6Quick 版本检查

Log: 修复 Qt 6.10+ 构建兼容性，调整 QuickPrivate 依赖检测

Influence:
1. 测试 Qt 6.10.0 以下版本，确认无回归问题
2. 测试 Qt 6.10.0 及以上版本，确保构建成功
3. 检查 QT_NO_PRIVATE_MODULE_WARNING 设置不干扰其他模块
4. 验证测试在不同 Qt 配置下均能正确编译和运行

## Summary by Sourcery

Adjust QuickPrivate dependency detection to support Qt 6.10+ while retaining compatibility with older Qt versions.

Bug Fixes:
- Fix Qt 6.10+ build compatibility by conditionally detecting the QuickPrivate dependency and suppressing private-module warnings.

Enhancements:
- Preserve compatibility with Qt versions older than 6.10 by skipping the QuickPrivate lookup for those versions.