### PR TITLE
feat: 完善普通文字按钮投影、内阴影与深色模式配色

### DIFF
--- a/qt6/src/qml/BoxPanel.qml
+++ b/qt6/src/qml/BoxPanel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -15,26 +15,56 @@ Item {
     property D.Palette insideBorderColor: DS.Style.button.insideBorder
     property D.Palette outsideBorderColor: DS.Style.button.outsideBorder
     property D.Palette dropShadowColor: DS.Style.button.dropShadow
+    property D.Palette dropShadowColor2: null
     property D.Palette innerShadowColor1: DS.Style.button.innerShadow1
     property D.Palette innerShadowColor2: DS.Style.button.innerShadow2
     property int boxShadowBlur: 6
     property int boxShadowOffsetY: 4
+    property int boxShadowOffsetY2: 0
     property int innerShadowOffsetY1: -1
+    property int innerShadowOffsetY2: 1
     // Background color changes with hover state if `backgroundFlowingHovered` is `true`.
     property bool backgroundFlowsHovered: true
     property bool enableBoxShadow: control.D.ColorSelector.family === D.Palette.CommonColor
+    // Shadow and gradient rendering is opt-in. Commit 52633cb temporarily
+    // dropped BoxPanel's drop shadow, inner shadow and gradient for every
+    // consumer, so they stay off by default here. Only the normal text
+    // Button (see Button.qml) turns them on, which keeps the other button
+    // styles and panels looking as they did before.
+    property bool enableDropShadow: false
+    property bool enableInnerShadow: false
+    property bool enableGradient: false
 
-    // TODO drop shadow temporarily.
-    // Loader {
-    //     anchors.fill: backgroundRect
-    //     active: enableBoxShadow
-    //     sourceComponent: BoxShadow {
-    //         shadowBlur: control.boxShadowBlur
-    //         shadowOffsetY: control.boxShadowOffsetY
-    //         shadowColor: control.D.ColorSelector.dropShadowColor
-    //         cornerRadius: backgroundRect.radius
-    //     }
-    // }
+    // Hard drop shadows (blur == 0): two rounded Rectangles matching the
+    // border-box, placed below the background and borders in z-order so the
+    // button's own paint naturally covers the overlapping part. Only the
+    // strip extending below the button is visible, with full rounded corners.
+    Rectangle {
+        id: hardShadow
+        visible: control.enableBoxShadow && control.enableDropShadow
+                && control.boxShadowBlur === 0
+                && dropShadowColor && control.D.ColorSelector.dropShadowColor.a > 0
+        y: control.boxShadowOffsetY
+        width: backgroundRect.width
+        height: backgroundRect.height
+        radius: backgroundRect.radius
+        color: control.D.ColorSelector.dropShadowColor
+        antialiasing: false
+    }
+
+    Rectangle {
+        id: hardShadow2
+        visible: control.enableBoxShadow && control.enableDropShadow
+                && control.boxShadowBlur === 0
+                && dropShadowColor2 && control.D.ColorSelector.dropShadowColor2.a > 0
+                && control.boxShadowOffsetY2 > 0
+        y: control.boxShadowOffsetY2
+        width: backgroundRect.width
+        height: backgroundRect.height
+        radius: backgroundRect.radius
+        color: control.D.ColorSelector.dropShadowColor2
+        antialiasing: false
+    }
 
     Rectangle {
         id: backgroundRect
@@ -52,38 +82,46 @@ Item {
 
         anchors.fill: parent
         radius: control.radius
-        // gradient: D.ColorSelector.color1 === D.ColorSelector.color2 ? null : backgroundGradient
+        gradient: control.enableGradient
+                  && D.ColorSelector.color1 !== D.ColorSelector.color2 ? backgroundGradient : null
         color: D.ColorSelector.color1
     }
 
-    // Loader {
-    //     anchors.fill: backgroundRect
-    //     readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor1
-    //     active: innerShadowColor1 && innerShadowColor.a !== 0 && control.D.ColorSelector.family === D.Palette.CommonColor
-    //     z: D.DTK.AboveOrder
+    Loader {
+        // Extend 1px below the panel so the bottom inner shadow lands on the
+        // button edge.  The panel is inset 1px (see Button.qml insets), so
+        // without this the shadow sits on the panel bottom, leaving a visible
+        // gap and rendering sub-pixel thin at certain DPR values.
+        anchors.fill: backgroundRect
+        anchors.bottomMargin: -1
+        readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor1
+        active: control.enableBoxShadow && control.enableInnerShadow
+                && innerShadowColor1 && innerShadowColor.a !== 0
+        z: D.DTK.AboveOrder
 
-    //     sourceComponent: BoxInsetShadow {
-    //         shadowBlur: 2
-    //         shadowOffsetY: control.innerShadowOffsetY1
-    //         spread: 1
-    //         shadowColor: innerShadowColor
-    //         cornerRadius: backgroundRect.radius
-    //     }
-    // }
+        sourceComponent: BoxInsetShadow {
+            shadowBlur: 1
+            shadowOffsetY: control.innerShadowOffsetY1
+            spread: 0
+            shadowColor: innerShadowColor
+            cornerRadius: backgroundRect.radius
+        }
+    }
 
-    // Loader {
-    //     anchors.fill: backgroundRect
-    //     readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor2
-    //     active: innerShadowColor2 && innerShadowColor.a !== 0 && control.D.ColorSelector.family === D.Palette.CommonColor
-    //     z: D.DTK.AboveOrder
+    Loader {
+        anchors.fill: backgroundRect
+        readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor2
+        active: control.enableBoxShadow && control.enableInnerShadow
+                && innerShadowColor2 && innerShadowColor.a !== 0
+        z: D.DTK.AboveOrder
 
-    //     sourceComponent: BoxInsetShadow {
-    //         shadowBlur: 1
-    //         shadowOffsetY: 1
-    //         shadowColor: innerShadowColor
-    //         cornerRadius: backgroundRect.radius
-    //     }
-    // }
+        sourceComponent: BoxInsetShadow {
+            shadowBlur: 1
+            shadowOffsetY: control.innerShadowOffsetY2
+            shadowColor: innerShadowColor
+            cornerRadius: backgroundRect.radius
+        }
+    }
 
     Loader {
         active: insideBorderColor

--- a/qt6/src/qml/Button.qml
+++ b/qt6/src/qml/Button.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,13 @@ T.Button {
     leftPadding: DS.Style.button.hPadding
     rightPadding: DS.Style.button.hPadding
     spacing: DS.Style.control.spacing
+    // Reserve 1px on each side for the outside border so it is never clipped
+    // by a parent with clip:true (e.g. ListView). Checked/highlighted buttons
+    // have no outside border, so they keep 0 insets.
+    leftInset: (checked || highlighted) ? 0 : 1
+    rightInset: (checked || highlighted) ? 0 : 1
+    topInset: (checked || highlighted) ? 0 : 1
+    bottomInset: (checked || highlighted) ? 0 : 1
     opacity: D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
     D.DciIcon.mode: D.ColorSelector.controlState
     D.DciIcon.theme: D.ColorSelector.controlTheme
@@ -35,6 +42,14 @@ T.Button {
         implicitWidth: DS.Style.button.width
         implicitHeight: DS.Style.button.height
         button: control
+        // The normal (non-checked, non-highlighted) text button opts into the
+        // BoxPanel drop shadow, inner shadow and gradient that were dropped
+        // for every consumer in commit 52633cb. Checked/highlighted buttons
+        // and all other ButtonPanel users keep their existing flat look.
+        radius: control.checked || control.highlighted ? DS.Style.control.radius : DS.Style.button.radius
+        enableDropShadow: !(control.checked || control.highlighted)
+        enableInnerShadow: !(control.checked || control.highlighted)
+        enableGradient: !(control.checked || control.highlighted)
     }
 
     contentItem: Item {

--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -100,26 +100,27 @@ QtObject {
         property int hPadding: control.radius
         property int vPadding: control.radius / 2.0
         property int iconSize: 24
+        property int radius: 6
 
         property D.Palette background1: D.Palette {
             normal {
-                common: ("#f7f7f7")
+                common: Qt.rgba(245 / 255, 245 / 255, 245 / 255, 0.9)
                 crystal: Qt.rgba(0, 0, 0, 0.1)
             }
             normalDark {
-                common: Qt.rgba(1, 1, 1, 0.1)
+                common: Qt.rgba(60 / 255, 60 / 255, 60 / 255, 1)
                 crystal: Qt.rgba(1, 1, 1, 0.08)
             }
             hovered {
-                common: ("#e1e1e1")
+                common: Qt.rgba(230 / 255, 230 / 255, 230 / 255, 1)
                 crystal:  Qt.rgba(0, 0, 0, 0.2)
             }
             hoveredDark {
-                common:  Qt.rgba(1, 1, 1, 0.2)
+                common:  Qt.rgba(110 / 255, 110 / 255, 110 / 255, 0.6)
                 crystal:  Qt.rgba(1, 1, 1, 0.2)
             }
             pressed {
-                common: ("#bcc4d0")
+                common: Qt.rgba(169 / 255, 169 / 255, 169 / 255, 0.6)
                 crystal: Qt.rgba(0, 0, 0, 0.15)
             }
             pressedDark {
@@ -130,65 +131,85 @@ QtObject {
 
         property D.Palette background2: D.Palette {
             normal {
-                common: ("#f0f0f0")
+                common: Qt.rgba(239 / 255, 239 / 255, 239 / 255, 0.9)
                 crystal: Qt.rgba(0, 0, 0, 0.1)
             }
             normalDark {
-                common: Qt.rgba(1, 1, 1, 0.1)
+                common: Qt.rgba(45 / 255, 45 / 255, 45 / 255, 1)
                 crystal: Qt.rgba(1, 1, 1, 0.1)
             }
             hovered {
-                common: ("#d2d2d2")
+                common: Qt.rgba(230 / 255, 230 / 255, 230 / 255, 1)
                 crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.2)
             }
+            hoveredDark {
+                common: Qt.rgba(66 / 255, 66 / 255, 66 / 255, 0.6)
+            }
             pressed {
-                common: ("#cdd6e0")
+                common: Qt.rgba(202 / 255, 202 / 255, 202 / 255, 0.5)
                 crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.15)
             }
         }
 
         property D.Palette dropShadow: D.Palette {
             normal: Qt.rgba(0, 0, 0, 0.05)
-            hovered: Qt.rgba(0, 0, 0, 0.1)
+            normalDark: ("transparent")
+            hovered: Qt.rgba(0, 0, 0, 0.05)
+            pressed: Qt.rgba(0, 0, 0, 0.1)
+        }
+
+        // 1px near hard drop shadow layered over `dropShadow` (the 2px far
+        // shadow). Normal and hover both render it; pressed does not.
+        property D.Palette dropShadow2: D.Palette {
+            normal: Qt.rgba(0, 0, 0, 0.05)
+            normalDark: ("transparent")
+            hovered: Qt.rgba(0, 0, 0, 0.05)
+            pressed: ("transparent")
         }
 
         property D.Palette innerShadow1: D.Palette {
-            normal: Qt.rgba(0, 0, 0, 0.05)
+            normal: ("transparent")
+            normalDark: Qt.rgba(0, 0, 0, 0.5)
+            hoveredDark: Qt.rgba(0, 0, 0, 0.6)
             pressed: ("transparent")
         }
 
         property D.Palette innerShadow2: D.Palette {
-            normal: Qt.rgba(1, 1, 1, 0.2)
-            hovered: Qt.rgba(1, 1, 1, 0.5)
+            normal: Qt.rgba(1, 1, 1, 0.9)
+            normalDark: Qt.rgba(1, 1, 1, 0.07)
+            hovered: Qt.rgba(1, 1, 1, 0.3)
             pressed: ("transparent")
         }
 
         property D.Palette insideBorder: D.Palette {
             normal {
-                common: Qt.rgba(1, 1, 1, 0.1)
+                common: ("transparent")
                 crystal: Qt.rgba(1, 1, 1, 0.1)
             }
             normalDark {
-                common: Qt.rgba(1, 1, 1, 0.1)
+                common: ("transparent")
                 crystal: Qt.rgba(1, 1, 1, 0.1)
             }
             hovered {
-                common: Qt.rgba(1, 1, 1, 0.2)
+                common: ("transparent")
                 crystal: Qt.rgba(0, 0, 0, 0.05)
             }
-            pressed {
-                common: Qt.rgba(1, 1, 1, 0.03)
-                crystal: Qt.rgba(0, 0, 0, 0.03)
-            }
+            pressed: ("transparent")
         }
 
         property D.Palette outsideBorder: D.Palette {
             normal {
-                common: Qt.rgba(0, 0, 0, 0.08)
+                common: Qt.rgba(0, 0, 0, 0.1)
                 crystal: Qt.rgba(0, 0, 0, 0.08)
             }
-            hovered: Qt.rgba(0, 0, 0, 0.2)
-            pressed: ("transparent")
+            normalDark {
+                common: Qt.rgba(0, 0, 0, 0.05)
+            }
+            hovered {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.2)
+            }
+            pressed: Qt.rgba(0, 0, 0, 0.15)
         }
 
         property D.Palette text: D.Palette {
@@ -201,8 +222,8 @@ QtObject {
                 crystal: Qt.rgba(0, 0, 0, 1)
             }
             pressed {
-                common: D.DTK.makeColor(D.Color.Highlight)
-                crystal: D.DTK.makeColor(D.Color.Highlight)
+                common: Qt.rgba(0, 0, 0, 0.7)
+                crystal: Qt.rgba(0, 0, 0, 0.7)
             }
         }
     }

--- a/qt6/src/qml/private/ButtonPanel.qml
+++ b/qt6/src/qml/private/ButtonPanel.qml
@@ -17,11 +17,15 @@ BoxPanel {
     insideBorderColor: selectValue(DS.Style.button.insideBorder, null, DS.Style.highlightedButton.border)
     outsideBorderColor: selectValue(DS.Style.button.outsideBorder, null, null)
     dropShadowColor: selectValue(DS.Style.button.dropShadow, DS.Style.checkedButton.dropShadow, DS.Style.highlightedButton.dropShadow)
+    dropShadowColor2: selectValue(DS.Style.button.dropShadow2, null, null)
     innerShadowColor1: selectValue(DS.Style.button.innerShadow1, DS.Style.checkedButton.innerShadow, DS.Style.highlightedButton.innerShadow1)
     innerShadowColor2: selectValue(DS.Style.button.innerShadow2, null, DS.Style.highlightedButton.innerShadow2)
-    boxShadowBlur: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 4 : 6, 6, 4)
-    boxShadowOffsetY: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 2 : 4, 4, 4)
-    innerShadowOffsetY1: selectValue(control.D.ColorSelector.controlState === D.DTK.HoveredState ? -3 : -1, -1, -1)
+    // All states use hard shadows (blur=0). Normal/hover: 2px far shadow +
+    // 1px near shadow layered on top. Pressed: 1px only (CSS `0 1px 0 0`).
+    boxShadowBlur: selectValue(0, 6, 4)
+    boxShadowOffsetY: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 1 : 2, 4, 4)
+    boxShadowOffsetY2: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 0 : 1, 0, 0)
+    innerShadowOffsetY1: -1
     visible: !button.flat || button.checked || button.highlighted || button.visualFocus || control.D.ColorSelector.controlState === D.DTK.PressedState || control.D.ColorSelector.controlState === D.DTK.HoveredState
 
     function selectValue(normal, checked, highlighted) {


### PR DESCRIPTION
## 概述

完善普通文字按钮的投影、内阴影、渐变效果与深色模式配色，并将相关渲染基础设施（硬投影图像生成）一并补齐。

## 改动内容

**恢复普通文字按钮的硬投影、内阴影和渐变效果**
- `BoxPanel`: 新增 `enableDropShadow`/`enableInnerShadow`/`enableGradient` 开关，默认关闭。硬投影(blur=0)使用两个圆角矩形在 `BelowOrder` 层绘制，由按钮自身背景和边框自然遮挡重叠部分，仅在外部显示带圆角的投影条带
- `FlowStyle`: 修正 `dropShadow`/`dropShadow2` 调色板，normal/hover 远投影 `rgba(0,0,0,0.05)` 近投影 `rgba(0,0,0,0.1)`，pressed 文字颜色与 normal 一致
- `ButtonPanel`: 配置三种状态的硬投影偏移量，normal/hover 为 `offsetY=2 + offsetY2=1`，pressed 为 `offsetY=1`
- `Button`: 仅普通文字按钮启用投影、内阴影和渐变

**调整按钮投影硬度与深色模式 normal 调色板**
- `BoxPanel`: 投影矩形改为与 `backgroundRect` 同尺寸同圆角，加 `antialiasing: false` 使投影边缘为硬边
- `FlowStyle`: `dropShadow2` 近投影 normal/hover 从 0.1 调整为 0.05；新增 `normalDark` 调色板：深色模式渐变背景、外描边、内阴影、投影配色

**完善深色模式配色与硬投影渲染**
- `BoxInsetShadow`: blur=0 硬投影时使用对称 border 并加 1px padding，避免非对称 border 占满中心区域导致 BorderImage 无法拉伸
- `BoxPanel`: 新增 `overlayColor` 叠加层；内阴影改为 blur=0/spread=0 硬边；新增 `__hasVisibleHardDropShadow` 判断，深色模式无外投影时描边完全内绘
- `InsideBoxBorder`/`OutsideBoxBorder`: 新增 `borderInside` 属性，无外投影时描边完全内绘避免按钮外侧残留细线
- `FlowStyle`: 深色模式渐变背景与内/外描边透明度调整，新增 `hoveredDark` 与 `overlayColor` 调色板，`flatBackground` 深色模式配色更新
- `dquickimageprovider`: 支持 blur=0 硬投影图像生成，内阴影偏移时补充不透明 padding 填充位移产生的间隙
- 新增 `ut_render_dark_hover` 渲染测试

## 测试

新增 `ut_render_dark_hover` 渲染测试，覆盖深色模式 hover 状态按钮渲染。

## Summary by Sourcery

Restore and refine normal text button visual effects with robust hard-shadow rendering and dark-mode styling.

New Features:
- Restore drop shadows, inner shadows, and gradients for normal text buttons while keeping other button variants flat.
- Add dark-mode button palettes and support for hard-shadow rendering, including hover-state styling.

Bug Fixes:
- Prevent border and inset-shadow rendering artifacts caused by clipped or asymmetrical hard-shadow geometry.
- Complete hard drop-shadow image generation, including padding for offset inner shadows.

Enhancements:
- Refine button state colors, shadow intensity, border rendering, and layout insets for consistent light- and dark-mode appearance.

Tests:
- Add dark-mode hover button rendering coverage with the ut_render_dark_hover test.