### PR TITLE
ToolButton: 深色模式 hover/pressed 毛玻璃效果 + checked 状态样式重构

### DIFF
--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -427,6 +427,92 @@ QtObject {
         property int height: 30
         property int iconSize: 16
         property int indicatorRightMargin: 6
+
+        property int radius: 6
+
+        // Checked tool buttons render as a subtle overlay chip with an
+        // accent-colored icon, instead of reusing the solid accent-fill
+        // checked button style shared with Button/ItemDelegate/etc.
+        property D.Palette checkedBackground: D.Palette {
+            normal {
+                common: Qt.rgba(0, 0, 0, 0.1)
+                crystal: Qt.rgba(0, 0, 0, 0.1)
+            }
+            normalDark {
+                common: Qt.rgba(0, 0, 0, 0.3)
+                crystal: Qt.rgba(0, 0, 0, 0.3)
+            }
+            hovered {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
+            }
+            hoveredDark {
+                common: Qt.rgba(0, 0, 0, 0.35)
+                crystal: Qt.rgba(0, 0, 0, 0.35)
+            }
+            pressed {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
+            }
+            pressedDark {
+                common: Qt.rgba(0, 0, 0, 0.35)
+                crystal: Qt.rgba(0, 0, 0, 0.35)
+            }
+        }
+
+        property D.Palette checkedText: D.Palette {
+            normal: D.DTK.makeColor(D.Color.Highlight)
+            normalDark: D.DTK.makeColor(D.Color.Highlight)
+            hovered: D.DTK.makeColor(D.Color.Highlight)
+            hoveredDark: D.DTK.makeColor(D.Color.Highlight)
+            pressed: D.DTK.makeColor(D.Color.Highlight)
+            pressedDark: D.DTK.makeColor(D.Color.Highlight)
+        }
+
+        // Inner shadow for the checked chip. Light mode uses a subtle
+        // 10% black; dark mode uses 50% black so the bottom inset line
+        // stays visible against the translucent overlay.
+        property D.Palette checkedShadow: D.Palette {
+            normal: Qt.rgba(0, 0, 0, 0.1)
+            normalDark: Qt.rgba(0, 0, 0, 0.5)
+            hovered: Qt.rgba(0, 0, 0, 0.1)
+            hoveredDark: Qt.rgba(0, 0, 0, 0.5)
+            pressed: Qt.rgba(0, 0, 0, 0.1)
+            pressedDark: Qt.rgba(0, 0, 0, 0.5)
+        }
+
+        // Background for non-checked tool buttons. Uses the Palette's
+        // built-in state mechanism: 'normal' is transparent, 'hovered'
+        // and 'pressed' apply a subtle tint. The ColorSelector selects
+        // the correct state automatically, no manual controlState check
+        // is needed. Dark-mode hover adds backdrop blur + inset bevel in
+        // ToolButton.qml on top of the hoveredDark tint.
+        property D.Palette background: D.Palette {
+            normal {
+                common: Qt.rgba(0, 0, 0, 0)
+                crystal: Qt.rgba(0, 0, 0, 0)
+            }
+            normalDark {
+                common: Qt.rgba(0, 0, 0, 0)
+                crystal: Qt.rgba(0, 0, 0, 0)
+            }
+            hovered {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
+            }
+            hoveredDark {
+                common: Qt.rgba(20.0 / 255, 20.0 / 255, 20.0 / 255, 0.2)
+                crystal: Qt.rgba(20.0 / 255, 20.0 / 255, 20.0 / 255, 0.2)
+            }
+            pressed {
+                common: Qt.rgba(0, 0, 0, 0.2)
+                crystal: Qt.rgba(0, 0, 0, 0.2)
+            }
+            pressedDark {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
+            }
+        }
     }
 
     property QtObject radioButton: QtObject {

--- a/qt6/src/qml/ToolButton.qml
+++ b/qt6/src/qml/ToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -10,12 +10,11 @@ import org.deepin.dtk.private 1.0 as P
 
 T.ToolButton {
     id: control
-    property D.Palette textColor: {
-        if (D.DTK.hasAnimation)
-            return checked ? DS.Style.highlightedButton.text : (highlighted ? DS.Style.highlightedButton.text : DS.Style.button.text)
+    // The checked chip is now a dedicated ToolButton style, so the checked
+    // text palette stays consistent whether animations are enabled or not.
+    property D.Palette textColor: checked ? DS.Style.toolButton.checkedText : (highlighted ? DS.Style.highlightedButton.text : DS.Style.button.text)
 
-        return checked ? DS.Style.checkedButton.text : (highlighted ? DS.Style.highlightedButton.text : DS.Style.button.text)
-    }
+    property D.Palette checkedShadow: DS.Style.toolButton.checkedShadow
 
     implicitWidth: DS.Style.control.implicitWidth(control)
     implicitHeight: DS.Style.control.implicitHeight(control)
@@ -114,22 +113,94 @@ T.ToolButton {
         implicitHeight: DS.Style.toolButton.height
         button: control
         outsideBorderColor: null
+        insideBorderColor: null
+        radius: DS.Style.toolButton.radius
 
+        // Non-checked tool buttons: bind color1 to the background palette
+        // which has transparent 'normal', tinted 'hovered' and 'pressed'
+        // states. The ColorSelector picks the state automatically, and
+        // ButtonPanel's default visibility shows the panel when hovered
+        // or pressed (flat buttons are hidden in normal state).
         Binding on color1 {
-            when: D.DTK.hasAnimation
-            value: D.Palette {
-                normal {
-                    common: Qt.rgba(0, 0, 0, 0.1)
-                }
-            }
+            when: !control.checked
+            value: DS.Style.toolButton.background
         }
         Binding on color2 {
-            when: D.DTK.hasAnimation
+            when: !control.checked
             value: buttonPanel.color1
         }
-        Binding on visible {
-            when: D.DTK.hasAnimation
-            value: control.hovered && !control.checked
+
+        // Dark-theme hover frosted-glass chip for non-checked tool buttons:
+        // backdrop blur (radius 15, saturation 100%) plus a 1px white top
+        // inset highlight and 1px black bottom inset shadow, over the
+        // translucent dark tint from background (rgba(20,20,20,0.2)).
+        // The blur is platform-gated; the inset bevel shows regardless.
+        readonly property bool __darkHover: !control.checked
+            && D.DTK.themeType === D.ApplicationHelper.DarkType
+            && buttonPanel.D.ColorSelector.controlState === D.DTK.HoveredState
+
+        D.InWindowBlur {
+            id: hoverBlur
+            anchors.fill: parent
+            radius: 15
+            saturation: 1.0
+            offscreen: true
+            visible: buttonPanel.__darkHover && hoverBlur.valid
+            z: -1
+
+            D.ItemViewport {
+                anchors.fill: parent
+                fixed: true
+                sourceItem: hoverBlur.content
+                radius: buttonPanel.radius
+                hideSource: false
+            }
+        }
+
+        // Inner shadow 1: 1px white top inset highlight.
+        D.BoxInsetShadow {
+            anchors.fill: parent
+            visible: buttonPanel.__darkHover
+            z: D.DTK.AboveOrder
+            cornerRadius: buttonPanel.radius
+            shadowColor: Qt.rgba(1, 1, 1, 0.1)
+            shadowOffsetX: 0
+            shadowOffsetY: 1
+            shadowBlur: 1
+        }
+
+        // Inner shadow 2: 1px black bottom inset shadow.
+        D.BoxInsetShadow {
+            anchors.fill: parent
+            visible: buttonPanel.__darkHover
+            z: D.DTK.AboveOrder
+            cornerRadius: buttonPanel.radius
+            shadowColor: Qt.rgba(0, 0, 0, 0.5)
+            shadowOffsetX: 0
+            shadowOffsetY: -1
+            shadowBlur: 1
+        }
+
+        // Checked tool buttons use a subtle overlay chip with an accent icon
+        // instead of the shared accent-fill checked button style.
+        Binding on color1 {
+            when: control.checked
+            value: DS.Style.toolButton.checkedBackground
+        }
+        Binding on color2 {
+            when: control.checked
+            value: DS.Style.toolButton.checkedBackground
+        }
+        // Inset bottom shadow for the checked chip.
+        D.BoxInsetShadow {
+            anchors.fill: parent
+            visible: control.checked
+            z: D.DTK.AboveOrder
+            cornerRadius: buttonPanel.radius
+            shadowColor: control.D.ColorSelector.checkedShadow
+            shadowOffsetX: 0
+            shadowOffsetY: -1
+            shadowBlur: 1
         }
     }
 }

--- a/qt6/src/qml/overridable/InWindowBlur.qml
+++ b/qt6/src/qml/overridable/InWindowBlur.qml
@@ -10,6 +10,7 @@ Item {
     id :control
     property bool offscreen: false
     property alias radius: blur.blurMax
+    property alias saturation: blur.saturation
     property alias multiplier: blur.blurMultiplier
     property alias content: blur
     default property alias data: blitter.data


### PR DESCRIPTION
## ToolButton: 深色模式 hover/pressed 毛玻璃效果 + checked 状态样式重构

### 背景

ToolButton 在深色模式下的 hover/pressed 样式效果不理想：hover 时使用的是浅灰色 tint（rgba(1,1,1,0.15)），缺乏层次感和质感；checked 状态复用了 Button 的 accent 填充样式，视觉上与 ToolButton 的轻量风格不匹配。

本 PR 重新设计了 ToolButton 的深色模式 hover/pressed 样式，并重构了 checked 状态的独立样式。

### 修改内容

#### 1. 深色模式 hover 效果（毛玻璃）

深色模式 hover 新增了背景模糊（backdrop blur）效果，模拟设计稿中的磨砂玻璃质感：

- 背景模糊 `radius: 15`，`saturation: 100%`
- 背景色 `rgba(20, 20, 20, 0.2)` 半透明深色 tint
- 顶部 1px 白色内阴影 `rgba(255, 255, 255, 0.1)`（高光）
- 底部 1px 黑色内阴影 `rgba(0, 0, 0, 0.5)`（暗角）
- 圆角 `6px`

模糊效果通过 `D.InWindowBlur` 实现，使用 `D.ItemViewport` 裁剪到圆角形状。模糊功能受平台限制（`valid` 属性门控），在不支持的平台仅显示 tint + 内阴影。

#### 2. 深色模式 pressed 效果

深色模式 pressed 使用纯色 tint `rgba(0, 0, 0, 0.15)`，不叠加模糊和内阴影，保持简洁。

#### 3. checked 状态样式重构

checked 状态不再复用 Button 的 accent 填充样式，改为独立的 overlay chip 样式：

- 背景：浅色模式 `rgba(0, 0, 0, 0.1~0.15)`，深色模式 `rgba(0, 0, 0, 0.3~0.35)`
- 文字/图标：统一使用 Highlight 强调色
- 底部 1px 内阴影：浅色 `rgba(0, 0, 0, 0.1)`，深色 `rgba(0, 0, 0, 0.5)`

#### 4. InWindowBlur 组件增强

`InWindowBlur.qml` 新增 `saturation` 属性别名，暴露 MultiEffect 的饱和度参数，使 ToolButton 的深色 hover 可以设置 100% 饱和度。

### 涉及文件

| 文件 | 改动 |
|------|------|
| `qt6/src/qml/overridable/InWindowBlur.qml` | 新增 `saturation` 属性别名 |
| `qt6/src/qml/FlowStyle.qml` | `toolButton` QtObject 新增 `radius`、`checkedBackground`、`checkedText`、`checkedShadow`、`hoverBackground` 属性 |
| `qt6/src/qml/ToolButton.qml` | 重构 `textColor`、`background` 的 Binding 逻辑，新增深色 hover 毛玻璃和内阴影、checked 状态独立样式 |

### 已知限制

- 背景模糊（backdrop blur）依赖平台 GPU 支持，在软件渲染或不支持 InWindowBlur 的环境下会降级为纯 tint + 内阴影（仅去掉模糊，视觉效果保持一致）
- ButtonBox 有自己的 `backgroundPanel` 动画覆盖层，与本 PR 的 ToolButton hover 样式独立，不在本次修改范围内

## Summary by Sourcery

Redesign ToolButton state styling to provide polished dark-theme hover feedback and a lightweight checked appearance.

New Features:
- Add a dark-theme frosted-glass hover treatment for non-checked ToolButtons with platform-gated blur and inset highlights/shadows.

Enhancements:
- Refactor ToolButton checked styling into a lightweight overlay chip with consistent accent-colored text and state-aware shadows.
- Expose saturation configuration through InWindowBlur and centralize ToolButton state palettes and sizing in FlowStyle.