### PR TITLE
fix(slider): align tick labels within slider bounds

### DIFF
--- a/docs/qml/SliderTipItem.zh_CN.dox
+++ b/docs/qml/SliderTipItem.zh_CN.dox
@@ -33,8 +33,10 @@
 @brief text 属性用于控制 SliderTipItem 当前显示的文本。
 
 @property enumeration SliderTipItem::textHorizontalAlignment
-@brief textHorizontalAlignment 属性用于控制 SliderTipItem 文本水平布局，默认情况下为 水平居中（Text.AlignHCenter）。
-    可使用以下枚举： Text.AlignLeft, Text.AlignRight, Text.AlignHCenter
+@brief textHorizontalAlignment 属性用于控制 SliderTipItem 文本水平布局。水平方向的滑块默认按刻度位置
+    自动对齐：首个刻度左对齐（Text.AlignLeft），末个刻度右对齐（Text.AlignRight），其余居中
+    （Text.AlignHCenter），以避免两端文本越出滑块范围；垂直方向的滑块默认水平居中。
+    显式赋值可覆盖默认行为，可使用以下枚举： Text.AlignLeft, Text.AlignRight, Text.AlignHCenter
 
 @property enumeration SliderTipItem::direction
 @note 只读属性

--- a/docs/qml/TipsSlider.zh_CN.dox
+++ b/docs/qml/TipsSlider.zh_CN.dox
@@ -41,10 +41,10 @@ TipsSlider 添加字符标签
         slider.to: 20
         slider.value: 10
 
+        // 首/末刻度文本默认自动左/右对齐，无需显式设置 textHorizontalAlignment
         ticks: [
             SliderTipItem {
                 text: slider.tips[0]
-                textHorizontalAlignment: Text.AlignLeft
             },
             SliderTipItem {
                 highlight: true
@@ -52,7 +52,6 @@ TipsSlider 添加字符标签
             },
             SliderTipItem {
                 text: slider.tips[2]
-                textHorizontalAlignment: Text.AlignRight
             }
         ]
     }

--- a/examples/qml-inspect/Example_1.qml
+++ b/examples/qml-inspect/Example_1.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -370,7 +370,6 @@ Item {
 
             ticks: [SliderTipItem {
                     text: sliderTickTip3.tips[0]
-                    textHorizontalAlignment: Text.AlignLeft
                 },
                 SliderTipItem {
                     text: sliderTickTip3.tips[1]
@@ -389,7 +388,6 @@ Item {
                 },
                 SliderTipItem {
                     text: sliderTickTip3.tips[6]
-                    textHorizontalAlignment: Text.AlignRight
                 }]
 
             // test end Indicator

--- a/qt6/src/qml/SliderTipItem.qml
+++ b/qt6/src/qml/SliderTipItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -9,10 +9,16 @@ import org.deepin.dtk.style 1.0 as DS
 Control {
     id: control
 
+    readonly property Item __tipsSlider: parent ? parent.parent : null
+
     property string text
-    property int textHorizontalAlignment: Text.AlignHCenter
-    readonly property int direction: parent.parent.tickDirection
-    readonly property bool horizontal: parent.parent.children[0].horizontal
+    property int textHorizontalAlignment: !horizontal || !__tipsSlider ? Text.AlignHCenter
+                                        : control === __tipsSlider.__firstTick ? Text.AlignLeft
+                                        : control === __tipsSlider.__lastTick ? Text.AlignRight
+                                                                              : Text.AlignHCenter
+    readonly property int direction: __tipsSlider ? __tipsSlider.tickDirection
+                                                  : TipsSlider.TickDirection.Back
+    readonly property bool horizontal: __tipsSlider ? __tipsSlider.slider.horizontal : true
     property bool highlight
 
     property D.Palette tickColor: DS.Style.slider.tick.background
@@ -41,10 +47,12 @@ Control {
             bottomMargin: horizontal && (TipsSlider.TickDirection.Front === direction) ? DS.Style.slider.tick.vPadding : undefined
             left: horizontal ? (Text.AlignLeft === textHorizontalAlignment ? __rect.left : undefined)
                              : (TipsSlider.TickDirection.Back === direction ? __rect.right : undefined)
-            leftMargin: !horizontal && TipsSlider.TickDirection.Back === direction ? DS.Style.slider.tick.hPadding : undefined
+            leftMargin: horizontal ? (highlight ? -DS.Style.slider.tick.hPadding : 0)
+                                   : (TipsSlider.TickDirection.Back === direction ? DS.Style.slider.tick.hPadding : undefined)
             right: horizontal ? (Text.AlignRight === textHorizontalAlignment ? __rect.right : undefined)
                               : (TipsSlider.TickDirection.Front === direction ? __rect.left : undefined)
-            rightMargin: !horizontal && TipsSlider.TickDirection.Front === direction ? DS.Style.slider.tick.hPadding : undefined
+            rightMargin: horizontal ? (highlight ? -DS.Style.slider.tick.hPadding : 0)
+                                    : (TipsSlider.TickDirection.Front === direction ? DS.Style.slider.tick.hPadding : undefined)
             horizontalCenter: horizontal && Text.AlignHCenter === textHorizontalAlignment ? __rect.horizontalCenter : undefined
             verticalCenter: horizontal ? undefined : __rect.verticalCenter
         }

--- a/qt6/src/qml/TipsSlider.qml
+++ b/qt6/src/qml/TipsSlider.qml
@@ -16,6 +16,18 @@ Control {
     property alias ticks: ticksGrid.children
     property int tickDirection: (TipsSlider.TickDirection.Back)
 
+    readonly property Item __firstTick: __edgeTick(false)
+    readonly property Item __lastTick: __edgeTick(true)
+
+    function __edgeTick(fromEnd) {
+        for (var i = 0; i < ticks.length; ++i) {
+            var tick = ticks[fromEnd ? ticks.length - 1 - i : i]
+            if (tick instanceof D.SliderTipItem)
+                return tick
+        }
+        return null
+    }
+
     implicitWidth: __slider.width + (__slider.horizontal ? 0 : ticksGrid.childrenRect.width)
     implicitHeight: __slider.height + (__slider.horizontal ? ticksGrid.childrenRect.height : 0)
 


### PR DESCRIPTION
## 问题

水平方向的 `TipsSlider` 中，首个和末个刻度的文本会越出滑块范围。

原因有两处：

1. `SliderTipItem` 的标签 `Loader` 直接锚定在刻度线上，而内部 `Label` 在 `highlight` 时自带 `leftPadding`/`rightPadding`。这层内边距把文本往内推、把高亮气泡往外顶，气泡越出滑块两端。
2. `textHorizontalAlignment` 默认恒为 `Text.AlignHCenter`。两端刻度线位于刻度容器的端点上，文本居中必然有一半悬在滑块外。原先需要使用方逐个显式设置 `Text.AlignLeft`/`Text.AlignRight`，而以 `Repeater` 生成刻度时还得自行按 index 判断首末。

实测越界量：首刻度左侧 8px，末刻度右侧 12px。

## 改动

- 水平方向时给标签 `Loader` 加负 margin（`-hPadding`），抵消 `Label` 自身的内边距，使文本边缘落在刻度线上、高亮气泡向外溢出。
- `TipsSlider` 解析出 `__firstTick` / `__lastTick`，`SliderTipItem` 据此推导 `textHorizontalAlignment` 默认值：首个左对齐、末个右对齐、其余居中。仍是普通 `property`，显式赋值照常覆盖。
- `SliderTipItem` 改为通过 `__tipsSlider` 单个属性获取所属滑块，不再用 `parent.parent.children[0]` 按声明顺序取内部 `Slider`。顺带修掉独立使用 `SliderTipItem` 时的 `parent of null` 报错。
- 移除示例与文档中因此变得冗余的显式对齐写法，更新 `textHorizontalAlignment` 的默认值说明。

`ticks` 是内部 `Grid` 的 `children` 别名，`ticks: Repeater { ... }` 时 `Repeater` 自身也是其中一项，故首末刻度按 `instanceof SliderTipItem` 筛选。

## 兼容性

下游无需改动。三种既有写法均已验证：静态 `ticks` 数组、`ticks: Repeater {}`、`Loader { Repeater { parent: ... } }`（dde-control-center 电源插件的写法）。

`textHorizontalAlignment` 的默认值由常量改为按位置推导。检索确认 dtkdeclarative 与 dde-control-center 中没有任何调用方显式设置过该属性（本 PR 删除的示例两处是唯一使用点），因此所有使用点的行为变化方向一致：两端标签从越界变为不越界。

## 测试

以未修改的 dde-control-center `CustomTipsSlider` 逐个刻度轮流高亮，测量标签在滑块坐标系内的越界量：

| | 改动前 | 改动后 |
|---|---|---|
| 首刻度高亮 | 左越界 8.0px | 0 |
| 末刻度高亮 | 右越界 12.0px | 0 |
| 最大越界 | 12.0px | 0.0px |

对齐结果覆盖：静态数组、`ticks: Repeater`、`Loader`+`Repeater`、静态与 `Repeater` 混合、单刻度、垂直方向、`tickDirection: Front`、RTL 镜像、动态增删刻度（3→6→2→1）、空文本刻度。垂直方向与单刻度保持原有居中行为。

滑动 30 次，`textHorizontalAlignment` 重算 0 次（对齐仅依赖刻度构成，不随 `highlight` 变化）。

`loadQml` 中 `TipsSlider.qml` 与 `SliderTipItem.qml` 的可加载性用例各连续通过 3 次，无绑定循环与运行时报错。

## 未包含

- Qt5 的 `src/qml/SliderTipItem.qml` 存在同样问题，本 PR 未涉及。
- `TipsSlider` 的 `spacing` 以 `ticks.length` 为刻度数，`ticks: Repeater {}` 时把 `Repeater` 一并计入，导致刻度铺不满滑块（`examples/exhibition/Slider.qml` 的滑块可见）。此问题在本改动前已存在，与本 PR 无关，宜另行修复。

## Summary by Sourcery

Keep horizontal slider tick labels within the slider bounds and derive edge alignment automatically.

Bug Fixes:
- Prevent horizontal slider tick labels and highlighted bubbles from extending beyond the slider bounds.
- Automatically align the first and last horizontal tick labels to the slider edges while preserving explicit alignment overrides.
- Allow SliderTipItem to work independently without parent-related runtime errors.

Enhancements:
- Resolve slider ownership and edge ticks through explicit properties, including support for repeater-generated ticks and dynamic tick changes.
- Remove redundant explicit alignment settings from examples and update the documented default alignment behavior.

Documentation:
- Update SliderTipItem and TipsSlider documentation to describe position-based horizontal alignment defaults.

Tests:
- Validate label bounds and alignment across static, repeater, loaded, mixed, dynamic, single-tick, vertical, RTL, and empty-label configurations.