### PR TITLE
fix: adjust dark mode button style parameters and add soft shadow support / 修复深色模式按钮样式参数并新增柔和投影支持

### DIFF
--- a/qt6/src/qml/BoxPanel.qml
+++ b/qt6/src/qml/BoxPanel.qml
@@ -66,6 +66,22 @@ Item {
         antialiasing: false
     }
 
+    // Soft drop shadow (blur > 0): uses BoxShadow for blurred rendering.
+    // Active only when boxShadowBlur is non-zero (e.g. pressed state).
+    Loader {
+        active: control.enableBoxShadow && control.enableDropShadow
+                && control.boxShadowBlur > 0
+                && dropShadowColor && control.D.ColorSelector.dropShadowColor.a > 0
+        anchors.fill: parent
+
+        sourceComponent: BoxShadow {
+            cornerRadius: backgroundRect.radius
+            shadowBlur: control.boxShadowBlur
+            shadowOffsetY: control.boxShadowOffsetY
+            shadowColor: control.D.ColorSelector.dropShadowColor
+        }
+    }
+
     Rectangle {
         id: backgroundRect
         property alias color1: control.color1

--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -108,7 +108,7 @@ QtObject {
                 crystal: Qt.rgba(0, 0, 0, 0.1)
             }
             normalDark {
-                common: Qt.rgba(60 / 255, 60 / 255, 60 / 255, 1)
+                common: Qt.rgba(60 / 255, 60 / 255, 60 / 255, 0.6)
                 crystal: Qt.rgba(1, 1, 1, 0.08)
             }
             hovered {
@@ -116,7 +116,7 @@ QtObject {
                 crystal:  Qt.rgba(0, 0, 0, 0.2)
             }
             hoveredDark {
-                common:  Qt.rgba(110 / 255, 110 / 255, 110 / 255, 0.6)
+                common:  Qt.rgba(110 / 255, 110 / 255, 110 / 255, 0.4)
                 crystal:  Qt.rgba(1, 1, 1, 0.2)
             }
             pressed {
@@ -124,8 +124,8 @@ QtObject {
                 crystal: Qt.rgba(0, 0, 0, 0.15)
             }
             pressedDark {
-                common:  Qt.rgba(1, 1, 1, 0.05)
-                crystal:  Qt.rgba(1, 1, 1, 0.05)
+                common:  Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
+                crystal:  Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
             }
         }
 
@@ -135,7 +135,7 @@ QtObject {
                 crystal: Qt.rgba(0, 0, 0, 0.1)
             }
             normalDark {
-                common: Qt.rgba(45 / 255, 45 / 255, 45 / 255, 1)
+                common: Qt.rgba(45 / 255, 45 / 255, 45 / 255, 0.6)
                 crystal: Qt.rgba(1, 1, 1, 0.1)
             }
             hovered {
@@ -143,11 +143,15 @@ QtObject {
                 crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.2)
             }
             hoveredDark {
-                common: Qt.rgba(66 / 255, 66 / 255, 66 / 255, 0.6)
+                common: Qt.rgba(66 / 255, 66 / 255, 66 / 255, 0.4)
             }
             pressed {
                 common: Qt.rgba(202 / 255, 202 / 255, 202 / 255, 0.5)
                 crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.15)
+            }
+            pressedDark {
+                common: Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
+                crystal: Qt.rgba(46 / 255, 46 / 255, 46 / 255, 1)
             }
         }
 
@@ -156,6 +160,7 @@ QtObject {
             normalDark: ("transparent")
             hovered: Qt.rgba(0, 0, 0, 0.05)
             pressed: Qt.rgba(0, 0, 0, 0.1)
+            pressedDark: Qt.rgba(0, 0, 0, 0.4)
         }
 
         // 1px near hard drop shadow layered over `dropShadow` (the 2px far
@@ -169,9 +174,10 @@ QtObject {
 
         property D.Palette innerShadow1: D.Palette {
             normal: ("transparent")
-            normalDark: Qt.rgba(0, 0, 0, 0.5)
-            hoveredDark: Qt.rgba(0, 0, 0, 0.6)
+            normalDark: Qt.rgba(0, 0, 0, 0.2)
+            hoveredDark: Qt.rgba(0, 0, 0, 0.3)
             pressed: ("transparent")
+            pressedDark: ("transparent")
         }
 
         property D.Palette innerShadow2: D.Palette {
@@ -179,6 +185,7 @@ QtObject {
             normalDark: Qt.rgba(1, 1, 1, 0.07)
             hovered: Qt.rgba(1, 1, 1, 0.3)
             pressed: ("transparent")
+            pressedDark: Qt.rgba(1, 1, 1, 0.07)
         }
 
         property D.Palette insideBorder: D.Palette {
@@ -194,6 +201,7 @@ QtObject {
                 common: ("transparent")
                 crystal: Qt.rgba(0, 0, 0, 0.05)
             }
+            hoveredDark: ("transparent")
             pressed: ("transparent")
         }
 
@@ -210,6 +218,7 @@ QtObject {
                 crystal: Qt.rgba(0, 0, 0, 0.2)
             }
             pressed: Qt.rgba(0, 0, 0, 0.15)
+            pressedDark: ("transparent")
         }
 
         property D.Palette text: D.Palette {

--- a/qt6/src/qml/private/ButtonPanel.qml
+++ b/qt6/src/qml/private/ButtonPanel.qml
@@ -20,9 +20,10 @@ BoxPanel {
     dropShadowColor2: selectValue(DS.Style.button.dropShadow2, null, null)
     innerShadowColor1: selectValue(DS.Style.button.innerShadow1, DS.Style.checkedButton.innerShadow, DS.Style.highlightedButton.innerShadow1)
     innerShadowColor2: selectValue(DS.Style.button.innerShadow2, null, DS.Style.highlightedButton.innerShadow2)
-    // All states use hard shadows (blur=0). Normal/hover: 2px far shadow +
-    // 1px near shadow layered on top. Pressed: 1px only (CSS `0 1px 0 0`).
-    boxShadowBlur: selectValue(0, 6, 4)
+    // Normal/hover: hard shadows (blur=0) - 2px far shadow + 1px near
+    // shadow layered on top. Pressed: soft shadow (blur=1) via BoxShadow,
+    // offset 1px down.
+    boxShadowBlur: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 1 : 0, 6, 4)
     boxShadowOffsetY: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 1 : 2, 4, 4)
     boxShadowOffsetY2: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 0 : 1, 0, 0)
     innerShadowOffsetY1: -1


### PR DESCRIPTION
## Summary / 概述

Fix several dark mode (common family) button styling issues on the `v25-flowstyle` branch, and add soft shadow rendering support for the pressed state.

修复 `v25-flowstyle` 分支上深色模式（common 系列）按钮的若干样式问题，并为 pressed 状态新增柔和投影渲染支持。

## Changes / 变更内容

### FlowStyle.qml — dark mode button parameters / 深色模式按钮参数

| Parameter / 参数 | Before / 修改前 | After / 修改后 |
|---|---|---|
| `background1.normalDark.common` opacity | 1.0 | **0.6** |
| `background2.normalDark.common` opacity | 1.0 | **0.6** |
| `background1.hoveredDark.common` opacity | 0.6 | **0.4** |
| `background2.hoveredDark.common` opacity | 0.6 | **0.4** |
| `background1.pressedDark` | `rgba(1,1,1,0.05)` | **`rgba(40,40,40,1)`** |
| `background2.pressedDark` | *(missing — fell back to normalDark)* | **`rgba(46,46,46,1)`** |
| `dropShadow.pressedDark` | *(missing — fell back to normalDark=transparent)* | **`rgba(0,0,0,0.4)`** |
| `innerShadow1.normalDark` | `rgba(0,0,0,0.5)` | **`rgba(0,0,0,0.2)`** |
| `innerShadow1.hoveredDark` | `rgba(0,0,0,0.6)` | **`rgba(0,0,0,0.3)`** |
| `innerShadow1.pressedDark` | *(missing — fell back to normalDark)* | **`transparent`** |
| `innerShadow2.pressedDark` | *(missing — fell back to normalDark)* | **`rgba(255,255,255,0.07)`** |
| `insideBorder.hoveredDark` | *(missing — fell back to hovered light)* | **`transparent`** |
| `outsideBorder.pressedDark` | *(missing — fell back to normalDark)* | **`transparent`** |

> **Note / 说明**: DTK Palette fallback behavior: when `pressedDark` is missing, `Dark+Pressed` falls back to `Dark+Normal` (`normalDark`), **not** to `pressed` (Light). This caused the phantom black inner shadow in pressed state. Adding explicit `pressedDark` entries fixes this.

> **说明**: DTK Palette 回退机制：当 `pressedDark` 缺失时，`Dark+Pressed` 会回退到 `Dark+Normal`（`normalDark`），而**不是** `pressed`（浅色）。这导致 pressed 状态下出现了不应有的黑色内阴影。添加显式的 `pressedDark` 条目即可修复此问题。

### BoxPanel.qml — soft shadow rendering / 柔和投影渲染

- Added a `BoxShadow` `Loader` for soft drop shadow rendering when `boxShadowBlur > 0`.
- Hard shadow `Rectangle`s (`boxShadowBlur === 0`) and the soft shadow `Loader` (`boxShadowBlur > 0`) are mutually exclusive — only one renders at a time.
- Gated by `enableBoxShadow` and `enableDropShadow`, so checked/highlighted buttons are unaffected.

- 新增 `BoxShadow` `Loader`，当 `boxShadowBlur > 0` 时渲染柔和投影。
- 硬投影 `Rectangle`（`boxShadowBlur === 0`）与柔和投影 `Loader`（`boxShadowBlur > 0`）互斥，同一时刻只渲染一个。
- 受 `enableBoxShadow` 和 `enableDropShadow` 约束，不影响 checked/highlighted 按钮。

### ButtonPanel.qml — pressed shadow blur / pressed 投影模糊

- `boxShadowBlur`: pressed state uses `blur=1` (soft shadow), normal/hover use `0` (hard shadow).
- Updated stale comment to reflect the new behavior.

- `boxShadowBlur`：pressed 状态使用 `blur=1`（柔和投影），normal/hover 使用 `0`（硬投影）。
- 更新过时注释以反映新行为。

## Verification / 验证

- Compiles cleanly with no warnings (`make -j$(nproc)` in `build-dtk6/`).
- Verified visually in `dtk6-exhibition` example under dark theme: normal, hover, and pressed states all render correctly.

- 编译无警告（`build-dtk6/` 下 `make -j$(nproc)`）。
- 在 `dtk6-exhibition` 示例中深色主题下目视验证：normal、hover、pressed 状态均渲染正确。

## Summary by Sourcery

Fix dark-mode button appearance and add soft shadows for pressed states.

New Features:
- Add soft drop-shadow rendering for pressed buttons.

Bug Fixes:
- Correct dark-mode common button colors, opacity, shadows, and borders across normal, hover, and pressed states.

Enhancements:
- Use blurred pressed-state shadows while retaining hard shadows for normal and hover states.