### PR TITLE
fix(dciicon): restore smooth filtering for mixed-DPI scaling

### DIFF
--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -53,6 +53,7 @@ DialogWindow {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 0
                 display: D.IconLabel.IconOnly
+                smooth: control.smooth
                 icon.mode: control.D.ColorSelector.controlState
                 icon.theme: control.D.ColorSelector.controlTheme
                 icon.palette: D.DTK.makeIconPalette(control.palette)

--- a/qt6/src/qml/ActionButton.qml
+++ b/qt6/src/qml/ActionButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,7 @@ T.Button {
         height: DS.Style.button.iconSize
     }
     contentItem: D.DciIcon {
+        smooth: control.smooth
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState
         theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/Button.qml
+++ b/qt6/src/qml/Button.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -46,6 +46,7 @@ T.Button {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/qt6/src/qml/ButtonIndicator.qml
+++ b/qt6/src/qml/ButtonIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -16,6 +16,7 @@ Rectangle {
     color: D.ColorSelector.backgroundColor
 
     D.DciIcon {
+        smooth: control.smooth
         anchors.centerIn: parent
         sourceSize {
             width: DS.Style.buttonIndicator.iconSize

--- a/qt6/src/qml/CheckBox.qml
+++ b/qt6/src/qml/CheckBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,6 +32,7 @@ T.CheckBox {
         implicitWidth: DS.Style.checkBox.indicatorWidth
         implicitHeight: DS.Style.checkBox.indicatorHeight
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -45,6 +46,7 @@ T.CheckBox {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/CheckDelegate.qml
+++ b/qt6/src/qml/CheckDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.CheckDelegate {
         active: indicatorVisible
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -51,6 +52,7 @@ T.CheckDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -58,6 +58,7 @@ T.ComboBox {
                 }
 
                 D.DciIcon {
+                    smooth: control.smooth
                     sourceSize {
                         width: DS.Style.comboBox.edit.indicatorSize
                         height: DS.Style.comboBox.edit.indicatorSize
@@ -74,6 +75,7 @@ T.ComboBox {
         Component {
             id: normalIndicator
             D.DciIcon {
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.comboBox.iconSize
                     height: DS.Style.comboBox.iconSize
@@ -96,6 +98,7 @@ T.ComboBox {
             active: iconName
 
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/ControlGroup.qml
+++ b/qt6/src/qml/ControlGroup.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -100,6 +100,7 @@ ColumnLayout {
                 verticalAlignment: Qt.AlignVCenter
             }
             D.DciIcon {
+                smooth: title.smooth
                 rotation: root.isExpanded ? 0 : - 90
                 name: "arrow_ordinary_down"
                 mode: title.D.ColorSelector.controlState

--- a/qt6/src/qml/DialogTitleBar.qml
+++ b/qt6/src/qml/DialogTitleBar.qml
@@ -65,6 +65,7 @@ Item {
                 id: iconControl
                 visible: iconLabel.name !== ""
                 contentItem: D.DciIcon {
+                    smooth: iconControl.smooth
                     id: iconLabel
                     mode: iconControl.D.ColorSelector.controlState
                     theme: iconControl.D.ColorSelector.controlTheme

--- a/qt6/src/qml/IconButton.qml
+++ b/qt6/src/qml/IconButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -24,6 +24,7 @@ Button {
     }
 
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState

--- a/qt6/src/qml/ItemDelegate.qml
+++ b/qt6/src/qml/ItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -64,6 +64,7 @@ T.ItemDelegate {
         active: control.indicatorVisible && control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -77,6 +78,7 @@ T.ItemDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/qt6/src/qml/MenuItem.qml
+++ b/qt6/src/qml/MenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -39,6 +39,7 @@ T.MenuItem {
         rightPadding: control.mirrored ? Math.max(DS.Style.menu.item.contentPadding, indicatorPadding) : arrowPadding
         spacing: control.spacing
         mirrored: control.mirrored
+        smooth: control.smooth
         display: control.display
         alignment: Qt.AlignLeft
         text: control.text
@@ -63,6 +64,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             name: "menu_select"
@@ -85,6 +87,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             mirror: control.mirrored

--- a/qt6/src/qml/RadioButton.qml
+++ b/qt6/src/qml/RadioButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,6 +32,7 @@ T.RadioButton {
         implicitHeight: implicitWidth
 
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -45,6 +46,7 @@ T.RadioButton {
             anchors.centerIn: parent
             active: control.activeFocus
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/SearchEdit.qml
+++ b/qt6/src/qml/SearchEdit.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -28,6 +28,7 @@ LineEdit {
 
             // Search Icon
             D.DciIcon {
+                smooth: control.smooth
                 id: searchIcon
                 name: "action_search"
                 sourceSize: Qt.size(DS.Style.searchEdit.iconSize, DS.Style.searchEdit.iconSize)

--- a/qt6/src/qml/Slider.qml
+++ b/qt6/src/qml/Slider.qml
@@ -38,6 +38,7 @@ T.Slider {
     // draw handle
     handle: SliderHandle {
         id: __handle
+        smooth: control.smooth
         x: control.leftPadding + (control.horizontal ? control.visualPosition * (control.availableWidth - width) : 0)
         y: control.topPadding + (control.horizontal ? 0 : control.visualPosition * (control.availableHeight - height))
         width: control.horizontal ? DS.Style.slider.handle.width : DS.Style.slider.handle.height

--- a/qt6/src/qml/SpinBoxIndicator.qml
+++ b/qt6/src/qml/SpinBoxIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,7 @@ Control {
     Component {
         id: inactiveComponent
         D.DciIcon {
+            smooth: control.smooth
             id: icon
             sourceSize.width: DS.Style.spinBox.indicator.iconSize
             palette: D.DTK.makeIconPalette(control.palette)

--- a/qt6/src/qml/Switch.qml
+++ b/qt6/src/qml/Switch.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -37,6 +37,7 @@ T.Switch {
                 opacity: control.D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
 
                 D.DciIcon {
+                    smooth: control.smooth
                     x: Math.max(0, Math.min(parent.width - width, control.visualPosition * parent.width - (width / 2)))
                     y: (parent.height - height) / 2
                     width: DS.Style.switchButton.handleWidth
@@ -65,6 +66,7 @@ T.Switch {
         Component {
             id: animationIndicatorComp
             D.DciIcon {
+                smooth: control.smooth
                 id: switchIcon
                 implicitWidth: DS.Style.switchButton.indicatorWidth
                 implicitHeight: DS.Style.switchButton.indicatorHeight

--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -115,6 +115,7 @@ Item {
             Layout.leftMargin: DS.Style.titleBar.leftMargin
 
             D.DciIcon {
+                smooth: control.smooth
                 id: iconLabel
                 sourceSize {
                     width: DS.Style.titleBar.iconSize

--- a/qt6/src/qml/ToolButton.qml
+++ b/qt6/src/qml/ToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -49,6 +49,7 @@ T.ToolButton {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/qt6/src/qml/WindowButton.qml
+++ b/qt6/src/qml/WindowButton.qml
@@ -30,6 +30,7 @@ D.IconButton {
     leftPadding: 0
     rightPadding: 0
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         asynchronous: false
         palette: D.DTK.makeIconPalette(control.palette)

--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -266,7 +266,6 @@ DQuickDciIconImage::DQuickDciIconImage(QQuickItem *parent)
     connect(this, &DQuickDciIconImage::smoothChanged, d->imageItem, &QQuickImage::setSmooth);
     connect(d->imageItem, &QQuickItem::widthChanged, this, [d]() { d->scheduleLayout(); });
     connect(d->imageItem, &QQuickItem::heightChanged, this, [d]() { d->scheduleLayout(); });
-    connect(this, &QQuickItem::scaleChanged, this, [this]() {setSmooth(!qFuzzyCompare(scale(), 1.0)); });
 }
 
 DQuickDciIconImage::~DQuickDciIconImage()
@@ -485,7 +484,6 @@ void DQuickDciIconImage::componentComplete()
     D_D(DQuickDciIconImage);
     d->imageItem->componentComplete();
     QQuickItem::componentComplete();
-    setSmooth(!qFuzzyCompare(scale(), 1.0));
     d->layout();
 }
 

--- a/src/private/dquickiconlabel.cpp
+++ b/src/private/dquickiconlabel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -53,6 +53,10 @@ void DQuickIconLabelPrivate::createIconImage()
     image->setMode(icon.mode());
     image->setFallbackToQIcon(icon.fallbackToQIcon());
     image->imageItem()->setFallbackSource(icon.source());
+    // Keep the label's smooth property in sync with the internal image so that
+    // setting IconLabel.smooth in QML controls the icon's texture filtering.
+    image->setSmooth(q->smooth());
+    QObject::connect(q, &QQuickItem::smoothChanged, image, &QQuickItem::setSmooth);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     image->setRetainWhileLoading(true);
 #endif

--- a/src/qml/AboutDialog.qml
+++ b/src/qml/AboutDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -43,6 +43,7 @@ DialogWindow {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 0
                 display: D.IconLabel.IconOnly
+                smooth: control.smooth
                 icon.mode: control.D.ColorSelector.controlState
                 icon.theme: control.D.ColorSelector.controlTheme
                 icon.palette: D.DTK.makeIconPalette(control.palette)

--- a/src/qml/ActionButton.qml
+++ b/src/qml/ActionButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,7 @@ T.Button {
         height: DS.Style.button.iconSize
     }
     contentItem: D.DciIcon {
+        smooth: control.smooth
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState
         theme: control.D.ColorSelector.controlTheme

--- a/src/qml/Button.qml
+++ b/src/qml/Button.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -45,6 +45,7 @@ T.Button {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/src/qml/ButtonIndicator.qml
+++ b/src/qml/ButtonIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -16,6 +16,7 @@ Rectangle {
     color: D.ColorSelector.backgroundColor
 
     D.DciIcon {
+        smooth: control.smooth
         anchors.centerIn: parent
         sourceSize {
             width: DS.Style.buttonIndicator.iconSize

--- a/src/qml/CheckBox.qml
+++ b/src/qml/CheckBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.CheckBox {
         implicitWidth: DS.Style.checkBox.indicatorWidth
         implicitHeight: DS.Style.checkBox.indicatorHeight
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -44,6 +45,7 @@ T.CheckBox {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/CheckDelegate.qml
+++ b/src/qml/CheckDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,7 @@ T.CheckDelegate {
         active: control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -42,6 +43,7 @@ T.CheckDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/src/qml/ComboBox.qml
+++ b/src/qml/ComboBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -52,6 +52,7 @@ T.ComboBox {
                 }
 
                 D.DciIcon {
+                    smooth: control.smooth
                     sourceSize {
                         width: DS.Style.comboBox.edit.indicatorSize
                         height: DS.Style.comboBox.edit.indicatorSize
@@ -68,6 +69,7 @@ T.ComboBox {
         Component {
             id: normalIndicator
             D.DciIcon {
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.comboBox.iconSize
                     height: DS.Style.comboBox.iconSize
@@ -90,6 +92,7 @@ T.ComboBox {
             active: iconName
 
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/DialogTitleBar.qml
+++ b/src/qml/DialogTitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -65,6 +65,7 @@ Control {
             Layout.leftMargin: DS.Style.titleBar.leftMargin
 
             D.DciIcon {
+                smooth: control.smooth
                 id: iconLabel
                 visible: name !== ""
                 mode: control.D.ColorSelector.controlState

--- a/src/qml/IconButton.qml
+++ b/src/qml/IconButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -23,6 +23,7 @@ Button {
     }
 
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState

--- a/src/qml/ItemDelegate.qml
+++ b/src/qml/ItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -53,6 +53,7 @@ T.ItemDelegate {
         active: control.indicatorVisible && control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -66,6 +67,7 @@ T.ItemDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/src/qml/MenuItem.qml
+++ b/src/qml/MenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -38,6 +38,7 @@ T.MenuItem {
         rightPadding: control.mirrored ? indicatorPadding : arrowPadding
         spacing: control.spacing
         mirrored: control.mirrored
+        smooth: control.smooth
         display: control.display
         alignment: Qt.AlignLeft
         text: control.text
@@ -58,6 +59,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             name: "menu_select"
@@ -80,6 +82,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             mirror: control.mirrored

--- a/src/qml/RadioButton.qml
+++ b/src/qml/RadioButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.RadioButton {
         implicitHeight: implicitWidth
 
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -44,6 +45,7 @@ T.RadioButton {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/SearchEdit.qml
+++ b/src/qml/SearchEdit.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -27,6 +27,7 @@ LineEdit {
 
             // Search Icon
             D.DciIcon {
+                smooth: control.smooth
                 id: searchIcon
                 name: "action_search"
                 sourceSize.width: DS.Style.searchEdit.iconSize

--- a/src/qml/Slider.qml
+++ b/src/qml/Slider.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -36,6 +36,7 @@ T.Slider {
     // draw handle
     handle: SliderHandle {
         id: __handle
+        smooth: control.smooth
         x: control.leftPadding + (control.horizontal ? control.visualPosition * (control.availableWidth - width) : 0)
         y: control.topPadding + (control.horizontal ? 0 : control.visualPosition * (control.availableHeight - height))
         width: control.horizontal ? DS.Style.slider.handle.width : DS.Style.slider.handle.height

--- a/src/qml/SliderHandle.qml
+++ b/src/qml/SliderHandle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/src/qml/SpinBoxIndicator.qml
+++ b/src/qml/SpinBoxIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -28,6 +28,7 @@ Control {
     Component {
         id: inactiveComponent
         D.DciIcon {
+            smooth: control.smooth
             id: icon
             sourceSize.width: DS.Style.spinBox.indicator.iconSize
             palette: D.DTK.makeIconPalette(control.palette)

--- a/src/qml/Switch.qml
+++ b/src/qml/Switch.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,6 +32,7 @@ T.Switch {
         opacity: control.D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
 
         D.DciIcon {
+            smooth: control.smooth
             id: handle
             x: Math.max(0, Math.min(parent.width - width, control.visualPosition * parent.width - (width / 2)))
             y: (parent.height - height) / 2

--- a/src/qml/TitleBar.qml
+++ b/src/qml/TitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -110,6 +110,7 @@ Control {
             Layout.leftMargin: DS.Style.titleBar.leftMargin
 
             D.DciIcon {
+                smooth: control.smooth
                 id: iconLabel
                 sourceSize {
                     width: DS.Style.titleBar.iconSize

--- a/src/qml/ToolButton.qml
+++ b/src/qml/ToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -43,6 +43,7 @@ T.ToolButton {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/src/qml/WindowButton.qml
+++ b/src/qml/WindowButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -17,6 +17,7 @@ Control {
     palette.windowText: D.ColorSelector.textColor
     hoverEnabled: true
     contentItem: D.DciIcon {
+        smooth: control.smooth
         id: iconLoader
         palette: D.DTK.makeIconPalette(control.palette)
         sourceSize {


### PR DESCRIPTION
Remove the scale-based setSmooth(false) overrides in DQuickDciIconImage so icons fall back to the default smooth=true filtering, eliminating jaggies when the scene is downsampled to lower-DPI outputs. Forward IconLabel's smooth to its internal image and bind smooth: control.smooth in controls.

移除DQuickDciIconImage中基于scale的smooth强制覆盖，恢复默认平滑过滤，
修复混合DPI下场景降采样导致的图标锯齿。IconLabel的smooth转发到内部
图像，并在各控件中绑定smooth: control.smooth。

Log: 修复混合DPI下图标锯齿，恢复DciIcon平滑渲染
Influence: 所有使用DciIcon/IconLabel的控件（Button/ToolButton/CheckDelegate/ItemDelegate/MenuItem/AboutDialog等）在混合DPI下图标平滑渲染；外部可通过smooth属性控制图标过滤。

## Summary by Sourcery

Restore smooth icon rendering across mixed-DPI outputs while preserving control over filtering through existing smooth properties.

New Features:
- Expose smooth filtering control through IconLabel and propagate each control's smooth setting to its embedded icons.

Bug Fixes:
- Restore smooth icon filtering by removing scale-based overrides that caused jagged rendering when mixed-DPI scenes were downsampled.

Chores:
- Keep the Qt 5 and Qt 6 QML control implementations aligned with the icon-filtering behavior.