### PR TITLE
fix(dciicon): restore smooth filtering for mixed-DPI scaling

### DIFF
--- a/src/private/dquickdciiconimage.cpp
+++ b/src/private/dquickdciiconimage.cpp
@@ -266,7 +266,6 @@ DQuickDciIconImage::DQuickDciIconImage(QQuickItem *parent)
     connect(this, &DQuickDciIconImage::smoothChanged, d->imageItem, &QQuickImage::setSmooth);
     connect(d->imageItem, &QQuickItem::widthChanged, this, [d]() { d->scheduleLayout(); });
     connect(d->imageItem, &QQuickItem::heightChanged, this, [d]() { d->scheduleLayout(); });
-    connect(this, &QQuickItem::scaleChanged, this, [this]() {setSmooth(!qFuzzyCompare(scale(), 1.0)); });
 }
 
 DQuickDciIconImage::~DQuickDciIconImage()
@@ -485,7 +484,6 @@ void DQuickDciIconImage::componentComplete()
     D_D(DQuickDciIconImage);
     d->imageItem->componentComplete();
     QQuickItem::componentComplete();
-    setSmooth(!qFuzzyCompare(scale(), 1.0));
     d->layout();
 }
 

--- a/src/private/dquickiconlabel.cpp
+++ b/src/private/dquickiconlabel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -53,6 +53,10 @@ void DQuickIconLabelPrivate::createIconImage()
     image->setMode(icon.mode());
     image->setFallbackToQIcon(icon.fallbackToQIcon());
     image->imageItem()->setFallbackSource(icon.source());
+    // Keep the label's smooth property in sync with the internal image so that
+    // setting IconLabel.smooth in QML controls the icon's texture filtering.
+    image->setSmooth(q->smooth());
+    QObject::connect(q, &QQuickItem::smoothChanged, image, &QQuickItem::setSmooth);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     image->setRetainWhileLoading(true);
 #endif


### PR DESCRIPTION
Remove the scale-based setSmooth(false) overrides in DQuickDciIconImage so icons fall back to the default smooth=true filtering, eliminating jaggies when the scene is downsampled to lower-DPI outputs. Forward IconLabel's smooth to its internal image.

移除DQuickDciIconImage中基于scale的smooth强制覆盖，恢复默认平滑过滤，
修复混合DPI下场景降采样导致的图标锯齿。IconLabel的smooth转发到内部图像。

Log: 修复混合DPI下图标锯齿，恢复DciIcon平滑渲染
Influence: 所有使用DciIcon/IconLabel的控件在混合DPI下图标平滑渲染；外部可通过smooth属性控制图标过滤。

## Summary by Sourcery

Restore configurable smooth filtering for DciIcon and IconLabel images to prevent jagged icons when rendering across mixed-DPI outputs.

Bug Fixes:
- Restore smooth icon filtering for mixed-DPI rendering by removing scale-based filtering overrides.
- Ensure IconLabel's smooth setting controls filtering for its internal icon image.