### PR TITLE
Fix/dciicon smooth qml

### DIFF
--- a/qt6/src/qml/AboutDialog.qml
+++ b/qt6/src/qml/AboutDialog.qml
@@ -53,6 +53,7 @@ DialogWindow {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 0
                 display: D.IconLabel.IconOnly
+                smooth: control.smooth
                 icon.mode: control.D.ColorSelector.controlState
                 icon.theme: control.D.ColorSelector.controlTheme
                 icon.palette: D.DTK.makeIconPalette(control.palette)

--- a/qt6/src/qml/ActionButton.qml
+++ b/qt6/src/qml/ActionButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,7 @@ T.Button {
         height: DS.Style.button.iconSize
     }
     contentItem: D.DciIcon {
+        smooth: control.smooth
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState
         theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/Button.qml
+++ b/qt6/src/qml/Button.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -46,6 +46,7 @@ T.Button {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/qt6/src/qml/ButtonIndicator.qml
+++ b/qt6/src/qml/ButtonIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -16,6 +16,7 @@ Rectangle {
     color: D.ColorSelector.backgroundColor
 
     D.DciIcon {
+        smooth: control.smooth
         anchors.centerIn: parent
         sourceSize {
             width: DS.Style.buttonIndicator.iconSize

--- a/qt6/src/qml/CheckBox.qml
+++ b/qt6/src/qml/CheckBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,6 +32,7 @@ T.CheckBox {
         implicitWidth: DS.Style.checkBox.indicatorWidth
         implicitHeight: DS.Style.checkBox.indicatorHeight
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -45,6 +46,7 @@ T.CheckBox {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/CheckDelegate.qml
+++ b/qt6/src/qml/CheckDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.CheckDelegate {
         active: indicatorVisible
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -51,6 +52,7 @@ T.CheckDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/qt6/src/qml/ComboBox.qml
+++ b/qt6/src/qml/ComboBox.qml
@@ -58,6 +58,7 @@ T.ComboBox {
                 }
 
                 D.DciIcon {
+                    smooth: control.smooth
                     sourceSize {
                         width: DS.Style.comboBox.edit.indicatorSize
                         height: DS.Style.comboBox.edit.indicatorSize
@@ -74,6 +75,7 @@ T.ComboBox {
         Component {
             id: normalIndicator
             D.DciIcon {
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.comboBox.iconSize
                     height: DS.Style.comboBox.iconSize
@@ -96,6 +98,7 @@ T.ComboBox {
             active: iconName
 
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/ControlGroup.qml
+++ b/qt6/src/qml/ControlGroup.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -100,6 +100,7 @@ ColumnLayout {
                 verticalAlignment: Qt.AlignVCenter
             }
             D.DciIcon {
+                smooth: title.smooth
                 rotation: root.isExpanded ? 0 : - 90
                 name: "arrow_ordinary_down"
                 mode: title.D.ColorSelector.controlState

--- a/qt6/src/qml/DialogTitleBar.qml
+++ b/qt6/src/qml/DialogTitleBar.qml
@@ -66,6 +66,7 @@ Item {
                 visible: iconLabel.name !== ""
                 contentItem: D.DciIcon {
                     id: iconLabel
+                    smooth: iconControl.smooth
                     mode: iconControl.D.ColorSelector.controlState
                     theme: iconControl.D.ColorSelector.controlTheme
                     palette: D.DTK.makeIconPalette(iconControl.palette)

--- a/qt6/src/qml/IconButton.qml
+++ b/qt6/src/qml/IconButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -24,6 +24,7 @@ Button {
     }
 
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState

--- a/qt6/src/qml/ItemDelegate.qml
+++ b/qt6/src/qml/ItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -64,6 +64,7 @@ T.ItemDelegate {
         active: control.indicatorVisible && control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -77,6 +78,7 @@ T.ItemDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/qt6/src/qml/MenuItem.qml
+++ b/qt6/src/qml/MenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -39,6 +39,7 @@ T.MenuItem {
         rightPadding: control.mirrored ? Math.max(DS.Style.menu.item.contentPadding, indicatorPadding) : arrowPadding
         spacing: control.spacing
         mirrored: control.mirrored
+        smooth: control.smooth
         display: control.display
         alignment: Qt.AlignLeft
         text: control.text
@@ -63,6 +64,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             name: "menu_select"
@@ -85,6 +87,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             mirror: control.mirrored

--- a/qt6/src/qml/RadioButton.qml
+++ b/qt6/src/qml/RadioButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -32,6 +32,7 @@ T.RadioButton {
         implicitHeight: implicitWidth
 
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -45,6 +46,7 @@ T.RadioButton {
             anchors.centerIn: parent
             active: control.activeFocus
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/qt6/src/qml/SearchEdit.qml
+++ b/qt6/src/qml/SearchEdit.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,7 @@ LineEdit {
             // Search Icon
             D.DciIcon {
                 id: searchIcon
+                smooth: control.smooth
                 name: "action_search"
                 sourceSize: Qt.size(DS.Style.searchEdit.iconSize, DS.Style.searchEdit.iconSize)
                 palette: D.DTK.makeIconPalette(control.palette)

--- a/qt6/src/qml/Slider.qml
+++ b/qt6/src/qml/Slider.qml
@@ -38,6 +38,7 @@ T.Slider {
     // draw handle
     handle: SliderHandle {
         id: __handle
+        smooth: control.smooth
         x: control.leftPadding + (control.horizontal ? control.visualPosition * (control.availableWidth - width) : 0)
         y: control.topPadding + (control.horizontal ? 0 : control.visualPosition * (control.availableHeight - height))
         width: control.horizontal ? DS.Style.slider.handle.width : DS.Style.slider.handle.height

--- a/qt6/src/qml/SpinBoxIndicator.qml
+++ b/qt6/src/qml/SpinBoxIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -30,6 +30,7 @@ Control {
         id: inactiveComponent
         D.DciIcon {
             id: icon
+            smooth: control.smooth
             sourceSize.width: DS.Style.spinBox.indicator.iconSize
             palette: D.DTK.makeIconPalette(control.palette)
             name: direction === SpinBoxIndicator.IndicatorDirection.UpIndicator ? "entry_spinbox_up" : "entry_spinbox_down"

--- a/qt6/src/qml/Switch.qml
+++ b/qt6/src/qml/Switch.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -37,6 +37,7 @@ T.Switch {
                 opacity: control.D.ColorSelector.controlState === D.DTK.DisabledState ? 0.4 : 1
 
                 D.DciIcon {
+                    smooth: control.smooth
                     x: Math.max(0, Math.min(parent.width - width, control.visualPosition * parent.width - (width / 2)))
                     y: (parent.height - height) / 2
                     width: DS.Style.switchButton.handleWidth
@@ -66,6 +67,7 @@ T.Switch {
             id: animationIndicatorComp
             D.DciIcon {
                 id: switchIcon
+                smooth: control.smooth
                 implicitWidth: DS.Style.switchButton.indicatorWidth
                 implicitHeight: DS.Style.switchButton.indicatorHeight
 

--- a/qt6/src/qml/TitleBar.qml
+++ b/qt6/src/qml/TitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -116,6 +116,7 @@ Item {
 
             D.DciIcon {
                 id: iconLabel
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.titleBar.iconSize
                     height: DS.Style.titleBar.iconSize

--- a/qt6/src/qml/ToolButton.qml
+++ b/qt6/src/qml/ToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -49,6 +49,7 @@ T.ToolButton {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/qt6/src/qml/WindowButton.qml
+++ b/qt6/src/qml/WindowButton.qml
@@ -30,6 +30,7 @@ D.IconButton {
     leftPadding: 0
     rightPadding: 0
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         asynchronous: false
         palette: D.DTK.makeIconPalette(control.palette)

--- a/src/qml/AboutDialog.qml
+++ b/src/qml/AboutDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -43,6 +43,7 @@ DialogWindow {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: 0
                 display: D.IconLabel.IconOnly
+                smooth: control.smooth
                 icon.mode: control.D.ColorSelector.controlState
                 icon.theme: control.D.ColorSelector.controlTheme
                 icon.palette: D.DTK.makeIconPalette(control.palette)

--- a/src/qml/ActionButton.qml
+++ b/src/qml/ActionButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,7 @@ T.Button {
         height: DS.Style.button.iconSize
     }
     contentItem: D.DciIcon {
+        smooth: control.smooth
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState
         theme: control.D.ColorSelector.controlTheme

--- a/src/qml/Button.qml
+++ b/src/qml/Button.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -45,6 +45,7 @@ T.Button {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/src/qml/ButtonIndicator.qml
+++ b/src/qml/ButtonIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -16,6 +16,7 @@ Rectangle {
     color: D.ColorSelector.backgroundColor
 
     D.DciIcon {
+        smooth: control.smooth
         anchors.centerIn: parent
         sourceSize {
             width: DS.Style.buttonIndicator.iconSize

--- a/src/qml/CheckBox.qml
+++ b/src/qml/CheckBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.CheckBox {
         implicitWidth: DS.Style.checkBox.indicatorWidth
         implicitHeight: DS.Style.checkBox.indicatorHeight
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -44,6 +45,7 @@ T.CheckBox {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/CheckDelegate.qml
+++ b/src/qml/CheckDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,7 @@ T.CheckDelegate {
         active: control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -42,6 +43,7 @@ T.CheckDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/src/qml/ComboBox.qml
+++ b/src/qml/ComboBox.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -52,6 +52,7 @@ T.ComboBox {
                 }
 
                 D.DciIcon {
+                    smooth: control.smooth
                     sourceSize {
                         width: DS.Style.comboBox.edit.indicatorSize
                         height: DS.Style.comboBox.edit.indicatorSize
@@ -68,6 +69,7 @@ T.ComboBox {
         Component {
             id: normalIndicator
             D.DciIcon {
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.comboBox.iconSize
                     height: DS.Style.comboBox.iconSize
@@ -90,6 +92,7 @@ T.ComboBox {
             active: iconName
 
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/DialogTitleBar.qml
+++ b/src/qml/DialogTitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -66,6 +66,7 @@ Control {
 
             D.DciIcon {
                 id: iconLabel
+                smooth: control.smooth
                 visible: name !== ""
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/IconButton.qml
+++ b/src/qml/IconButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -23,6 +23,7 @@ Button {
     }
 
     contentItem: D.DciIcon {
+        smooth: control.smooth
         name: control.icon.name
         palette: D.DTK.makeIconPalette(control.palette)
         mode: control.D.ColorSelector.controlState

--- a/src/qml/ItemDelegate.qml
+++ b/src/qml/ItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -53,6 +53,7 @@ T.ItemDelegate {
         active: control.indicatorVisible && control.checked
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             palette: D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
             theme: control.D.ColorSelector.controlTheme
@@ -66,6 +67,7 @@ T.ItemDelegate {
         D.IconLabel {
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon
                        ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter

--- a/src/qml/MenuItem.qml
+++ b/src/qml/MenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -38,6 +38,7 @@ T.MenuItem {
         rightPadding: control.mirrored ? indicatorPadding : arrowPadding
         spacing: control.spacing
         mirrored: control.mirrored
+        smooth: control.smooth
         display: control.display
         alignment: Qt.AlignLeft
         text: control.text
@@ -58,6 +59,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             name: "menu_select"
@@ -80,6 +82,7 @@ T.MenuItem {
         }
 
         sourceComponent: D.DciIcon {
+            smooth: control.smooth
             sourceSize: Qt.size(DS.Style.menu.item.iconSize.width,
                                 DS.Style.menu.item.iconSize.height)
             mirror: control.mirrored

--- a/src/qml/RadioButton.qml
+++ b/src/qml/RadioButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -31,6 +31,7 @@ T.RadioButton {
         implicitHeight: implicitWidth
 
         D.DciIcon {
+            smooth: control.smooth
             anchors.centerIn: parent
             palette: control.D.DTK.makeIconPalette(control.palette)
             mode: control.D.ColorSelector.controlState
@@ -44,6 +45,7 @@ T.RadioButton {
             active: control.activeFocus
             anchors.centerIn: parent
             sourceComponent: D.DciIcon {
+                smooth: control.smooth
                 palette: control.D.DTK.makeIconPalette(control.palette)
                 mode: control.D.ColorSelector.controlState
                 theme: control.D.ColorSelector.controlTheme

--- a/src/qml/SearchEdit.qml
+++ b/src/qml/SearchEdit.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -28,6 +28,7 @@ LineEdit {
             // Search Icon
             D.DciIcon {
                 id: searchIcon
+                smooth: control.smooth
                 name: "action_search"
                 sourceSize.width: DS.Style.searchEdit.iconSize
                 palette: D.DTK.makeIconPalette(control.palette)

--- a/src/qml/Slider.qml
+++ b/src/qml/Slider.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -36,6 +36,7 @@ T.Slider {
     // draw handle
     handle: SliderHandle {
         id: __handle
+        smooth: control.smooth
         x: control.leftPadding + (control.horizontal ? control.visualPosition * (control.availableWidth - width) : 0)
         y: control.topPadding + (control.horizontal ? 0 : control.visualPosition * (control.availableHeight - height))
         width: control.horizontal ? DS.Style.slider.handle.width : DS.Style.slider.handle.height

--- a/src/qml/SliderHandle.qml
+++ b/src/qml/SliderHandle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/src/qml/SpinBoxIndicator.qml
+++ b/src/qml/SpinBoxIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,6 +29,7 @@ Control {
         id: inactiveComponent
         D.DciIcon {
             id: icon
+            smooth: control.smooth
             sourceSize.width: DS.Style.spinBox.indicator.iconSize
             palette: D.DTK.makeIconPalette(control.palette)
             name: direction === SpinBoxIndicator.IndicatorDirection.UpIndicator ? "entry_spinbox_up" : "entry_spinbox_down"

--- a/src/qml/Switch.qml
+++ b/src/qml/Switch.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -33,6 +33,7 @@ T.Switch {
 
         D.DciIcon {
             id: handle
+            smooth: control.smooth
             x: Math.max(0, Math.min(parent.width - width, control.visualPosition * parent.width - (width / 2)))
             y: (parent.height - height) / 2
             width: DS.Style.switchButton.handleWidth

--- a/src/qml/TitleBar.qml
+++ b/src/qml/TitleBar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -111,6 +111,7 @@ Control {
 
             D.DciIcon {
                 id: iconLabel
+                smooth: control.smooth
                 sourceSize {
                     width: DS.Style.titleBar.iconSize
                     height: DS.Style.titleBar.iconSize

--- a/src/qml/ToolButton.qml
+++ b/src/qml/ToolButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -43,6 +43,7 @@ T.ToolButton {
             width: parent.width - (indicator ? indicator.width : 0)
             spacing: control.spacing
             mirrored: control.mirrored
+            smooth: control.smooth
             display: control.display
             alignment: indicator ? Qt.AlignLeft | Qt.AlignVCenter : Qt.AlignCenter
             text: control.text

--- a/src/qml/WindowButton.qml
+++ b/src/qml/WindowButton.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -18,6 +18,7 @@ Control {
     hoverEnabled: true
     contentItem: D.DciIcon {
         id: iconLoader
+        smooth: control.smooth
         palette: D.DTK.makeIconPalette(control.palette)
         sourceSize {
             width: DS.Style.windowButton.width


### PR DESCRIPTION
## Summary by Sourcery

Ensure QML controls consistently propagate their smooth-rendering configuration to contained visual elements.

Bug Fixes:
- Propagate each control's smooth-rendering setting to its icons, icon labels, indicators, and slider handles so QML controls render smoothly and consistently.

Enhancements:
- Apply the smooth-rendering propagation consistently across both Qt6 and legacy QML component sets.

Chores:
- Update SPDX copyright years for the affected QML components.