### PR TITLE
fix: use formal parameter in ThemeMenu signal handler

### DIFF
--- a/qt6/src/qml/ThemeMenu.qml
+++ b/qt6/src/qml/ThemeMenu.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -14,7 +14,7 @@ Menu {
     ActionGroup {
         id: themeEG
         exclusive: true
-        onTriggered: {
+        onTriggered: function(action) {
             D.ApplicationHelper.setPaletteType(action.themeType)
         }
     }


### PR DESCRIPTION
## 修复 ThemeMenu.qml 信号处理器参数注入弃用警告

### 改动内容

将 qt6/src/qml/ThemeMenu.qml 第 17 行的 onTriggered: { 修改为 onTriggered: function(action) {，使用 Qt6 要求的 JavaScript 函数形式参数语法，消除信号参数隐式注入弃用警告。

### 背景

控制中心切换主题时，控制台输出弃用警告：Parameter "action" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead.

ActionGroup.triggered(Action action) 信号带 action 参数，Qt6 要求信号处理器以 function(param) 形式声明形式参数，而非隐式注入。

### Multica Issue

DDE-226

## Summary by Sourcery

Use an explicit formal parameter in the ThemeMenu action handler to maintain Qt 6 compatibility and eliminate deprecation warnings.

Bug Fixes:
- Update the ThemeMenu signal handler to declare its action parameter explicitly, removing the Qt 6 deprecation warning caused by implicit parameter injection.

Chores:
- Update the ThemeMenu copyright year through 2026.