### PR TITLE
fix: restyle crystal mode for normal text button in light and dark themes

### DIFF
--- a/qt6/src/qml/BoxPanel.qml
+++ b/qt6/src/qml/BoxPanel.qml
@@ -35,6 +35,18 @@ Item {
     property bool enableInnerShadow: false
     property bool enableGradient: false
 
+    // Gates the direct BoxInsetShadow inner bevel for crystal dark mode
+    // and excludes crystal dark from the Loader-based common inner shadow path.
+    readonly property bool __crystalDark: control.D.ColorSelector.family === D.Palette.CrystalColor
+        && D.DTK.themeType === D.ApplicationHelper.DarkType
+
+    // Shared visibility for crystal dark inner bevel. Pressed state
+    // shows only the flat background + blur, no inner shadow.
+    readonly property bool __crystalDarkBevel: control.__crystalDark
+        && control.enableBoxShadow
+        && control.enableInnerShadow
+        && control.D.ColorSelector.controlState !== D.DTK.PressedState
+
     // Hard drop shadows (blur == 0): two rounded Rectangles matching the
     // border-box, placed below the background and borders in z-order so the
     // button's own paint naturally covers the overlapping part. Only the
@@ -112,6 +124,7 @@ Item {
         anchors.bottomMargin: -1
         readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor1
         active: control.enableBoxShadow && control.enableInnerShadow
+                && !control.__crystalDark
                 && innerShadowColor1 && innerShadowColor.a !== 0
         z: D.DTK.AboveOrder
 
@@ -128,6 +141,7 @@ Item {
         anchors.fill: backgroundRect
         readonly property color innerShadowColor: control.D.ColorSelector.innerShadowColor2
         active: control.enableBoxShadow && control.enableInnerShadow
+                && !control.__crystalDark
                 && innerShadowColor2 && innerShadowColor.a !== 0
         z: D.DTK.AboveOrder
 
@@ -139,15 +153,35 @@ Item {
         }
     }
 
+    // Crystal dark inner shadows in a Loader so the shadow items are only
+    // created when the bevel is active. Colors are selected via controlState
+    // (a regular property with proper NOTIFY), not the palette ColorSelector
+    // readonly properties which do not reliably re-evaluate in a Loader on
+    // hover transitions.
     Loader {
-        active: insideBorderColor
+        active: control.__crystalDarkBevel
         anchors.fill: backgroundRect
         z: D.DTK.AboveOrder
 
-        sourceComponent: InsideBoxBorder {
-            radius: backgroundRect.radius
-            color: control.D.ColorSelector.insideBorderColor
-            borderWidth: DS.Style.control.borderWidth
+        sourceComponent: Item {
+            BoxInsetShadow {
+                anchors.fill: parent
+                cornerRadius: backgroundRect.radius
+                shadowColor: control.D.ColorSelector.controlState === D.DTK.HoveredState
+                             ? Qt.rgba(1, 1, 1, 0.1) : Qt.rgba(1, 1, 1, 0.05)
+                shadowOffsetX: 0
+                shadowOffsetY: 1
+                shadowBlur: 1
+            }
+            BoxInsetShadow {
+                anchors.fill: parent
+                cornerRadius: backgroundRect.radius
+                shadowColor: control.D.ColorSelector.controlState === D.DTK.HoveredState
+                             ? Qt.rgba(0, 0, 0, 0.5) : Qt.rgba(0, 0, 0, 0.4)
+                shadowOffsetX: 0
+                shadowOffsetY: -1
+                shadowBlur: 1
+            }
         }
     }
 

--- a/qt6/src/qml/Button.qml
+++ b/qt6/src/qml/Button.qml
@@ -39,6 +39,7 @@ T.Button {
     }
 
     background: P.ButtonPanel {
+        id: buttonPanel
         implicitWidth: DS.Style.button.width
         implicitHeight: DS.Style.button.height
         button: control
@@ -50,6 +51,42 @@ T.Button {
         enableDropShadow: !(control.checked || control.highlighted)
         enableInnerShadow: !(control.checked || control.highlighted)
         enableGradient: !(control.checked || control.highlighted)
+        // Crystal dark-mode needs box shadow enabled so the inner bevel
+        // (direct BoxInsetShadow in BoxPanel) renders. State-level gating
+        // (pressed hides the bevel) is handled in BoxPanel, not here.
+        enableBoxShadow: !(control.checked || control.highlighted)
+            && (buttonPanel.D.ColorSelector.family === D.Palette.CommonColor
+                || buttonPanel.__crystalDark)
+
+        // Crystal backdrop blur behind the translucent tint produces a
+        // frosted-glass chip. Active in all non-disabled crystal states;
+        // light theme additionally excludes the inactive state.
+        // Mirrors the ToolButton hover blur (radius 15, saturation 1.0,
+        // offscreen itemViewport).
+        readonly property bool __crystalBlur:
+            !control.checked && !control.highlighted
+            && buttonPanel.D.ColorSelector.family === D.Palette.CrystalColor
+            && buttonPanel.D.ColorSelector.controlState !== D.DTK.DisabledState
+            && (D.DTK.themeType === D.ApplicationHelper.DarkType
+                || buttonPanel.D.ColorSelector.controlState !== D.DTK.InactiveState)
+
+        D.InWindowBlur {
+            id: crystalBlur
+            anchors.fill: parent
+            radius: 15
+            saturation: 1.0
+            offscreen: true
+            visible: buttonPanel.__crystalBlur && crystalBlur.valid
+            z: -1
+
+            D.ItemViewport {
+                anchors.fill: parent
+                fixed: true
+                sourceItem: crystalBlur.content
+                radius: buttonPanel.radius
+                hideSource: false
+            }
+        }
     }
 
     contentItem: Item {

--- a/qt6/src/qml/FlowStyle.qml
+++ b/qt6/src/qml/FlowStyle.qml
@@ -105,53 +105,54 @@ QtObject {
         property D.Palette background1: D.Palette {
             normal {
                 common: Qt.rgba(245 / 255, 245 / 255, 245 / 255, 0.9)
-                crystal: Qt.rgba(0, 0, 0, 0.1)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
             }
             normalDark {
                 common: Qt.rgba(60 / 255, 60 / 255, 60 / 255, 0.6)
-                crystal: Qt.rgba(1, 1, 1, 0.08)
+                crystal: Qt.rgba(0, 0, 0, 0.2)
             }
             hovered {
                 common: Qt.rgba(230 / 255, 230 / 255, 230 / 255, 1)
-                crystal:  Qt.rgba(0, 0, 0, 0.2)
+                crystal:  Qt.rgba(1, 1, 1, 0.2)
             }
             hoveredDark {
                 common:  Qt.rgba(110 / 255, 110 / 255, 110 / 255, 0.4)
-                crystal:  Qt.rgba(1, 1, 1, 0.2)
+                crystal:  Qt.rgba(20 / 255, 20 / 255, 20 / 255, 0.2)
             }
             pressed {
                 common: Qt.rgba(169 / 255, 169 / 255, 169 / 255, 0.6)
-                crystal: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.3)
             }
             pressedDark {
                 common:  Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
-                crystal:  Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
+                crystal: Qt.rgba(0, 0, 0, 0.4)
             }
         }
 
         property D.Palette background2: D.Palette {
             normal {
                 common: Qt.rgba(239 / 255, 239 / 255, 239 / 255, 0.9)
-                crystal: Qt.rgba(0, 0, 0, 0.1)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
             }
             normalDark {
                 common: Qt.rgba(45 / 255, 45 / 255, 45 / 255, 0.6)
-                crystal: Qt.rgba(1, 1, 1, 0.1)
+                crystal: Qt.rgba(0, 0, 0, 0.2)
             }
             hovered {
                 common: Qt.rgba(230 / 255, 230 / 255, 230 / 255, 1)
-                crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.2)
+                crystal: Qt.rgba(1, 1, 1, 0.2)
             }
             hoveredDark {
                 common: Qt.rgba(66 / 255, 66 / 255, 66 / 255, 0.4)
+                crystal: Qt.rgba(20 / 255, 20 / 255, 20 / 255, 0.2)
             }
             pressed {
                 common: Qt.rgba(202 / 255, 202 / 255, 202 / 255, 0.5)
-                crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.3)
             }
             pressedDark {
                 common: Qt.rgba(40 / 255, 40 / 255, 40 / 255, 1)
-                crystal: Qt.rgba(46 / 255, 46 / 255, 46 / 255, 1)
+                crystal: Qt.rgba(0, 0, 0, 0.4)
             }
         }
 
@@ -160,7 +161,10 @@ QtObject {
             normalDark: ("transparent")
             hovered: Qt.rgba(0, 0, 0, 0.05)
             pressed: Qt.rgba(0, 0, 0, 0.1)
-            pressedDark: Qt.rgba(0, 0, 0, 0.4)
+            pressedDark {
+                common: Qt.rgba(0, 0, 0, 0.4)
+                crystal: ("transparent")
+            }
         }
 
         // 1px near hard drop shadow layered over `dropShadow` (the 2px far
@@ -189,18 +193,9 @@ QtObject {
         }
 
         property D.Palette insideBorder: D.Palette {
-            normal {
-                common: ("transparent")
-                crystal: Qt.rgba(1, 1, 1, 0.1)
-            }
-            normalDark {
-                common: ("transparent")
-                crystal: Qt.rgba(1, 1, 1, 0.1)
-            }
-            hovered {
-                common: ("transparent")
-                crystal: Qt.rgba(0, 0, 0, 0.05)
-            }
+            normal: ("transparent")
+            normalDark: ("transparent")
+            hovered: ("transparent")
             hoveredDark: ("transparent")
             pressed: ("transparent")
         }
@@ -208,16 +203,20 @@ QtObject {
         property D.Palette outsideBorder: D.Palette {
             normal {
                 common: Qt.rgba(0, 0, 0, 0.1)
-                crystal: Qt.rgba(0, 0, 0, 0.08)
+                crystal: ("transparent")
             }
             normalDark {
                 common: Qt.rgba(0, 0, 0, 0.05)
+                crystal: ("transparent")
             }
             hovered {
                 common: Qt.rgba(0, 0, 0, 0.15)
-                crystal: Qt.rgba(0, 0, 0, 0.2)
+                crystal: Qt.rgba(0, 0, 0, 0.1)
             }
-            pressed: Qt.rgba(0, 0, 0, 0.15)
+            pressed {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: ("transparent")
+            }
             pressedDark: ("transparent")
         }
 
@@ -232,7 +231,7 @@ QtObject {
             }
             pressed {
                 common: Qt.rgba(0, 0, 0, 0.7)
-                crystal: Qt.rgba(0, 0, 0, 0.7)
+                crystal: D.DTK.makeColor(D.Color.Highlight)
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR reworks the crystal-family rendering for the normal (non-checked, non-highlighted) text `Button` in both light and dark themes.

### Dark theme

- **Normal/hover**: render inner shadows via direct `BoxInsetShadow` items in `BoxPanel` (same approach as ToolButton dark hover), with white 1px top inset and black 1px bottom inset. Shadow colors are selected by `controlState` instead of the palette `ColorSelector`, whose `readonly property` binding in a `Loader` context does not reliably re-evaluate on hover transitions.
- **Pressed**: render only a flat `rgba(0,0,0,0.4)` background plus backdrop blur — no inner shadows, drop shadows, borders, or gradient.

### Light theme

- Crystal backdrop blur (radius 15, saturation 1.0) behind the translucent tint for normal/hover/pressed states.
- Hover keeps a subtle outside border; normal and pressed have no border.
- Pressed text color uses the highlight color instead of black.

### Files changed

- `qt6/src/qml/BoxPanel.qml` — crystal dark inner shadow rendering via direct `BoxInsetShadow`
- `qt6/src/qml/Button.qml` — crystal blur enablement, `enableBoxShadow` for crystal dark
- `qt6/src/qml/FlowStyle.qml` — updated crystal palette values for `background1`/`background2`, `dropShadow`, `insideBorder`, `outsideBorder`, `text`

---

## 中文说明

本次 PR 重构了普通文字按钮（非 checked、非 highlighted）的 crystal 样式，涵盖深浅两种主题。

### 深色模式

- **normal/hover**：通过 `BoxPanel` 中直接使用 `BoxInsetShadow` 渲染内阴影（与 ToolButton 深色 hover 实现方式一致），白色 1px 顶部内阴影 + 黑色 1px 底部内阴影。阴影颜色通过 `controlState` 选择，而非 palette `ColorSelector`，因为 `Loader` 上下文中的 `readonly property` 绑定在 hover 状态切换时无法可靠地重新求值。
- **pressed**：仅渲染 `rgba(0,0,0,0.4)` 背景色 + 背景模糊，无内阴影、外阴影、边框和渐变。

### 浅色模式

- 在半透明底色后添加 crystal 背景模糊（radius 15, saturation 1.0），覆盖 normal/hover/pressed 状态。
- hover 保留细微外边框；normal 和 pressed 无边框。
- pressed 文字颜色改用主题强调色。

### 修改文件

- `qt6/src/qml/BoxPanel.qml` — 深色 crystal 内阴影渲染，直接使用 `BoxInsetShadow`
- `qt6/src/qml/Button.qml` — crystal 背景模糊启用，深色 crystal 的 `enableBoxShadow`
- `qt6/src/qml/FlowStyle.qml` — 更新 `background1`/`background2`、`dropShadow`、`insideBorder`、`outsideBorder`、`text` 的 crystal 调色板值

## Summary by Sourcery

Restyle normal crystal text buttons with consistent frosted-glass visuals and state-appropriate light and dark theme treatment.

New Features:
- Add frosted-glass backdrop blur to normal crystal text buttons across applicable states and themes.

Bug Fixes:
- Correct crystal button state rendering so dark-mode hover transitions use reliable state-specific bevel colors and pressed buttons omit unintended shadows and borders.

Enhancements:
- Refine crystal button palettes for translucent backgrounds, borders, shadows, and pressed text across light and dark themes.