### PR TITLE
fix: use soft two-layer drop shadow for normal button

### DIFF
--- a/qt6/src/qml/BoxPanel.qml
+++ b/qt6/src/qml/BoxPanel.qml
@@ -94,6 +94,24 @@ Item {
         }
     }
 
+    // Second soft drop shadow layer (blur > 0), using dropShadowColor2
+    // and boxShadowOffsetY2. Mirrors the hardShadow2 rectangle that
+    // renders when blur == 0.
+    Loader {
+        active: control.enableBoxShadow && control.enableDropShadow
+                && control.boxShadowBlur > 0
+                && dropShadowColor2 && control.D.ColorSelector.dropShadowColor2.a > 0
+                && control.boxShadowOffsetY2 > 0
+        anchors.fill: parent
+
+        sourceComponent: BoxShadow {
+            cornerRadius: backgroundRect.radius
+            shadowBlur: control.boxShadowBlur
+            shadowOffsetY: control.boxShadowOffsetY2
+            shadowColor: control.D.ColorSelector.dropShadowColor2
+        }
+    }
+
     Rectangle {
         id: backgroundRect
         property alias color1: control.color1

--- a/qt6/src/qml/private/ButtonPanel.qml
+++ b/qt6/src/qml/private/ButtonPanel.qml
@@ -20,12 +20,13 @@ BoxPanel {
     dropShadowColor2: selectValue(DS.Style.button.dropShadow2, null, null)
     innerShadowColor1: selectValue(DS.Style.button.innerShadow1, DS.Style.checkedButton.innerShadow, DS.Style.highlightedButton.innerShadow1)
     innerShadowColor2: selectValue(DS.Style.button.innerShadow2, null, DS.Style.highlightedButton.innerShadow2)
-    // Normal/hover: hard shadows (blur=0) - 2px far shadow + 1px near
-    // shadow layered on top. Pressed: soft shadow (blur=1) via BoxShadow,
-    // offset 1px down.
-    boxShadowBlur: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 1 : 0, 6, 4)
-    boxShadowOffsetY: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 1 : 2, 4, 4)
-    boxShadowOffsetY2: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 0 : 1, 0, 0)
+    // Normal button: two soft shadow layers (blur=1) via BoxShadow.
+    // Far shadow (dropShadow) offset 1px down; near shadow (dropShadow2)
+    // offset 2px down in normal/hover, disabled in pressed. Checked/
+    // highlighted use their own blur/offset values.
+    boxShadowBlur: selectValue(1, 6, 4)
+    boxShadowOffsetY: selectValue(1, 4, 4)
+    boxShadowOffsetY2: selectValue(control.D.ColorSelector.controlState === D.DTK.PressedState ? 0 : 2, 0, 0)
     innerShadowOffsetY1: -1
     visible: !button.flat || button.checked || button.highlighted || button.visualFocus || control.D.ColorSelector.controlState === D.DTK.PressedState || control.D.ColorSelector.controlState === D.DTK.HoveredState
 


### PR DESCRIPTION
## Summary

Replace hard drop shadows (blur=0) with soft shadows (blur=1) for the normal (non-checked, non-highlighted) text button in all states. Add a second `BoxShadow` Loader in BoxPanel so the near shadow layer (`dropShadow2`) also renders in the soft shadow path, mirroring the existing `hardShadow2` rectangle.

## Changes

**BoxPanel.qml** — Add a second `BoxShadow` Loader (lines 97-113) that activates when `boxShadowBlur > 0` and `dropShadowColor2` is set, using `boxShadowOffsetY2` for the offset. Previously the soft shadow path only rendered one layer; the near shadow (`dropShadow2`) was silently lost.

**ButtonPanel.qml** — Update shadow parameters for the normal button:
- `boxShadowBlur`: `selectValue(1, 6, 4)` — all normal-button states now use blur=1 (was 0 for normal/hover, 1 for pressed)
- `boxShadowOffsetY`: `selectValue(1, 4, 4)` — normal/hover offset reduced from 2 to 1
- `boxShadowOffsetY2`: `selectValue(controlState === PressedState ? 0 : 2, 0, 0)` — near shadow offset 2px in normal/hover, disabled in pressed

## Effect (light mode, normal button, CommonColor)

| State | Far shadow (dropShadow) | Near shadow (dropShadow2) |
|---|---|---|
| Normal | blur=1, offsetY=1, rgba(0,0,0,0.05) | blur=1, offsetY=2, rgba(0,0,0,0.05) |
| Hover | blur=1, offsetY=1, rgba(0,0,0,0.05) | blur=1, offsetY=2, rgba(0,0,0,0.05) |
| Pressed | blur=1, offsetY=1, rgba(0,0,0,0.1) | disabled (transparent + offset=0) |

## 概述

将普通文本按钮的硬投影（blur=0）改为软投影（blur=1），所有状态均生效。在 BoxPanel 中新增第二个 BoxShadow Loader，使近阴影层（dropShadow2）在软投影路径下也能渲染，与原有的 hardShadow2 矩形保持一致。

### 改动文件

- **BoxPanel.qml**：新增第二个 BoxShadow Loader，在 `boxShadowBlur > 0` 时渲染 dropShadow2 近阴影层，使用 boxShadowOffsetY2 作为偏移。此前软投影路径只渲染一层，近阴影被静默丢弃。
- **ButtonPanel.qml**：调整普通按钮的投影参数，blur 统一为 1，远阴影偏移 1px，近阴影偏移 2px（normal/hover），pressed 关闭近阴影。

### 测试

```bash
QML_IMPORT_PATH=build-dtk6/plugins \
  LD_LIBRARY_PATH=build-dtk6/qt6/src \
  build-dtk6/examples/exhibition/dtk6-exhibition
```

编译通过，在 exhibition 示例中验证浅色模式 normal/hover/pressed 状态下两层软投影渲染正确。

## Summary by Sourcery

Improve normal button drop shadows by consistently using two-layer soft shadow rendering across button states.

Bug Fixes:
- Restore the second near-shadow layer for soft drop shadows so normal buttons render both shadow layers correctly.

Enhancements:
- Update normal button shadows to use consistent soft shadows across states, with adjusted offsets for normal, hover, and pressed interactions.