### PR TITLE
fix(palette): break QML Palette windowText binding loop from the read side

### DIFF
--- a/src/private/dquickcontrolpalette.cpp
+++ b/src/private/dquickcontrolpalette.cpp
@@ -80,6 +80,86 @@ static inline QPalette _d_getControlPalette(QQuickItem *item) {
 #endif
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+// Palette used for DTK color resolution (theme detection via Window, typed-color
+// resolving via Highlight / HighlightedText). Must NOT use toQPalette(): it reads
+// back the DTK-overridden `windowText` role and re-triggers its QML binding.
+// Accent roles come from the stable application palette; only Window is read from
+// the control (never overridden by DTK, safe for theme detection).
+static QPalette _d_getControlPaletteForResolve(QQuickItem *item, DGuiApplicationHelper::ColorType theme)
+{
+    QPalette palette = DGuiApplicationHelper::instance()->applicationPalette(theme);
+    if (item) {
+        if (const QQuickPalette *pa = item->property("palette").value<QQuickPalette *>()) {
+            if (QQuickColorGroup *active = pa->active()) {
+                palette.setColor(QPalette::Window, active->window());
+            }
+        }
+    }
+    return palette;
+}
+
+// Whether the control has a real Inactive palette group (used to decide the
+// inactive mask blending in getColorOf()). Must NOT use toQPalette(): it reads
+// back the DTK-overridden `windowText` and re-triggers its QML binding. Compares
+// Active vs Inactive groups role-by-role, excluding `windowText` (a DTK binding
+// artifact, not a real inactive-state difference) and NoRole.
+static bool _d_controlPaletteHasInactiveState(QQuickItem *item)
+{
+    if (!item)
+        return false;
+    const QQuickPalette *pa = item->property("palette").value<QQuickPalette *>();
+    if (!pa)
+        return false;
+    QQuickColorGroup *activeGroup = pa->active();
+    QQuickColorGroup *inactiveGroup = pa->inactive();
+    if (!activeGroup || !inactiveGroup)
+        return false;
+
+    // QQuickColorGroup::color(ColorRole) is private, so read each role through its
+    // public per-role accessor.
+    auto colorOf = [](QQuickColorGroup *g, QPalette::ColorRole r) -> QColor {
+        switch (r) {
+        case QPalette::WindowText:       return g->windowText();
+        case QPalette::Button:           return g->button();
+        case QPalette::Light:            return g->light();
+        case QPalette::Midlight:         return g->midlight();
+        case QPalette::Dark:             return g->dark();
+        case QPalette::Mid:              return g->mid();
+        case QPalette::Text:             return g->text();
+        case QPalette::BrightText:       return g->brightText();
+        case QPalette::ButtonText:       return g->buttonText();
+        case QPalette::Base:             return g->base();
+        case QPalette::Window:           return g->window();
+        case QPalette::Shadow:           return g->shadow();
+        case QPalette::Highlight:        return g->highlight();
+        case QPalette::HighlightedText:  return g->highlightedText();
+        case QPalette::Link:             return g->link();
+        case QPalette::LinkVisited:      return g->linkVisited();
+        case QPalette::AlternateBase:    return g->alternateBase();
+        case QPalette::NoRole:           return QColor(); // no public accessor; equal by default in both groups
+        case QPalette::ToolTipBase:      return g->toolTipBase();
+        case QPalette::ToolTipText:      return g->toolTipText();
+        case QPalette::PlaceholderText:  return g->placeholderText();
+        case QPalette::Accent:           return g->accent();
+        case QPalette::NColorRoles:      break;
+        }
+        return QColor();
+    };
+
+    QPalette compare;
+    for (int role = QPalette::WindowText; role < QPalette::NColorRoles; ++role) {
+        if (role == QPalette::WindowText || role == QPalette::NoRole)
+            continue; // windowText: DTK overrides it from QML (binding artifact, not a real inactive state).
+                     // NoRole: no public QQuickColorGroup accessor; left at default (equal in both groups).
+        const auto cr = static_cast<QPalette::ColorRole>(role);
+        compare.setColor(QPalette::Active, cr, colorOf(activeGroup, cr));
+        compare.setColor(QPalette::Inactive, cr, colorOf(inactiveGroup, cr));
+    }
+    return !compare.isEqual(QPalette::Inactive, QPalette::Active);
+}
+#endif
+
 static QMetaProperty findMetaPropertyFromSignalIndex(const QObject *obj, int signal_index) {
     QMetaProperty itemProperty;
     if (signal_index < 0)
@@ -838,8 +918,15 @@ QColor DQuickControlColorSelector::getColorOf(const DQuickControlPalette *palett
 
     QColor colorValue;
     if (targetColor.isTypedColor()) {
-        if (m_control)
+        if (m_control) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            // Resolve typed colors without reading back `windowText` (which would
+            // re-trigger its QML binding). Qt5 keeps the original path.
+            colorValue = targetColor.toColor(_d_getControlPaletteForResolve(m_control, state->controlTheme));
+#else
             colorValue = targetColor.toColor(_d_getControlPalette(m_control));
+#endif
+        }
     } else {
         colorValue = targetColor.color();
     }
@@ -855,11 +942,17 @@ QColor DQuickControlColorSelector::getColorOf(const DQuickControlPalette *palett
     bool shouldBlendInactive = useInactiveColor && state->controlState == DQMLGlobalObject::InactiveState;
     if (shouldBlendInactive) {
         if (m_control) {
-            // If the control's inactive palette is same as active palette, it means the control does not have a real 
-            // inactive state, we should not blend the color with inactive mask color, otherwise it will cause the 
+            // If the control's inactive palette is same as active palette, it means the control does not have a real
+            // inactive state, we should not blend the color with inactive mask color, otherwise it will cause the
             // color looks like disabled and hard to recognize.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            // Compare Active/Inactive groups without toQPalette() (reads back `windowText`)
+            // and excluding `windowText` (a binding artifact, not a real inactive state).
+            shouldBlendInactive = _d_controlPaletteHasInactiveState(m_control);
+#else
             const auto qpalette = _d_getControlPalette(m_control);
             shouldBlendInactive = !qpalette.isEqual(QPalette::Inactive, QPalette::Active);
+#endif
         }
     }
     if (shouldBlendInactive) {
@@ -1015,12 +1108,27 @@ void DQuickControlColorSelector::updateControlTheme()
     if (!m_control)
         return;
 
+    // Re-entrancy guard: writing `palette.windowText` emits QQuickPalette::changed synchronously
+    // and re-enters this slot while already inside an update cycle; skip the redundant recompute.
+    if (m_updateDepth > 0)
+        return;
+
+    ++m_updateDepth;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Detect theme from the control's Window role (never overridden by DTK) without
+    // toQPalette(), which would read back `windowText` and retrigger its QML binding.
+    const QPalette pa = _d_getControlPaletteForResolve(m_control, m_state->controlTheme);
+    const QColor windowColor = pa.color(QPalette::Window);
+#else
     const QPalette pa = _d_getControlPalette(m_control);
     const QColor windowColor = pa.color(QPalette::Window);
+#endif
 
     if (!windowColor.isValid()) {
         // When the palette changed, should update the properties if it's DColor type is variant color.
         updateAllColorProperties();
+        --m_updateDepth;
         return;
     }
 
@@ -1030,6 +1138,7 @@ void DQuickControlColorSelector::updateControlTheme()
         // When the palette changed, should update the properties if it's DColor type is variant color.
         updateAllColorProperties();
     }
+    --m_updateDepth;
 }
 
 bool DQuickControlColorSelector::updateControlState()
@@ -1052,12 +1161,16 @@ bool DQuickControlColorSelector::updateControlState()
 
 void DQuickControlColorSelector::updateAllColorProperties()
 {
+    ++m_updateDepth;
+
     for (int i = 0; i < m_metaObject->count(); ++i) {
         auto p = m_metaObject->name(i);
         if (p.isEmpty())
             continue;
         updatePropertyFromName(p);
     }
+
+    --m_updateDepth;
 }
 
 void DQuickControlColorSelector::recvPaletteColorChanged()

--- a/src/private/dquickcontrolpalette_p.h
+++ b/src/private/dquickcontrolpalette_p.h
@@ -420,6 +420,9 @@ private:
     };
     QScopedPointer<PaletteState> m_state;
     QList<QMetaObject::Connection> m_itemParentChangeConnections;
+    // Re-entrancy guard depth for updateControlTheme()/updateAllColorProperties() to skip
+    // re-entrant calls triggered by the `palette.windowText` binding writing the palette.
+    int m_updateDepth = 0;
 };
 
 DQUICK_END_NAMESPACE


### PR DESCRIPTION
1. Add Qt6-only `_d_getControlPaletteForResolve()`: resolve typed colors (Highlight / HighlightedText) from the stable application palette, and read only the Window role (theme detection) from the control -- never via QQuickPalette::toQPalette(), which reads back the DTK-overridden `palette.windowText` and re-triggers its QML binding
2. Add Qt6-only `_d_controlPaletteHasInactiveState()`: compare Active vs Inactive groups role-by-role excluding `windowText` (a binding artifact, not a real inactive-state difference), avoiding the third windowText read-back point in getColorOf()
3. Replace the three read points (typed-color branch / inactive gate / updateControlTheme theme detection) to use the new safe helpers
4. Add a re-entrancy guard (`m_updateDepth`) in updateControlTheme() to skip the redundant recompute triggered by the `palette.windowText` binding writing the palette

Influence:
1. Open control center; no more "Binding loop detected for property windowText" when operating Button / MenuItem / ItemDelegate
2. Verify checked/highlighted text and icon foreground still turn white (HighlightedText) in light theme, and accent-color changes are followed
3. Verify normal state keeps the default foreground color
4. Verify light/dark theme switching
5. Verify inactive state (window unfocused) text is not wrongly blended

fix(palette): 从读侧断开 QML Palette windowText 绑定环

1. 新增仅 Qt6 的 `_d_getControlPaletteForResolve()`：类型化颜色（Highlight/ HighlightedText）从稳定的应用调色板解析，仅 Window 角色（主题探测）从控件读取 —— 不再走 QQuickPalette::toQPalette()，避免读回被 DTK 覆盖的 `palette.windowText` 而重触发其 QML 绑定
2. 新增仅 Qt6 的 `_d_controlPaletteHasInactiveState()`：逐角色比较 Active/Inactive 组并排除 `windowText`（绑定产物，非真实 inactive 差异），消除 getColorOf() 中第三个 windowText 读回点
3. 三处读点（类型化分支 / inactive 门控 / updateControlTheme 主题探测）改用新的安全函数
4. 在 updateControlTheme() 增加重入守卫（`m_updateDepth`），跳过由 `palette.windowText` 绑定写 palette 触发的冗余重算

Influence:
1. 打开控制中心，操作 Button / MenuItem / ItemDelegate 不再出现 "Binding loop detected for property windowText"
2. 验证浅色主题下选中/高亮文字与图标前景仍为白色（HighlightedText），强调色变化跟随
3. 验证普通态保持默认前景色
4. 验证亮/暗主题切换
5. 验证窗口失焦 inactive 态文字不被误混合

PMS: Task-392413

## Summary by Sourcery

Break Qt 6 palette windowText binding loops from the read side while preserving correct control colors across themes and inactive states.

Bug Fixes:
- Prevent QML palette.windowText binding loops on Qt 6 controls while preserving typed-color resolution, theme detection, inactive-state handling, and accent-color updates.

Enhancements:
- Add safe palette resolution and inactive-state comparison that avoid reading back DTK-overridden windowText values.
- Guard palette theme and color updates against redundant re-entrant recalculations.